### PR TITLE
feat(dashboard): build dashboard home skeleton with dark theme

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,16 +1,162 @@
-import { LogoutButton } from "@/components/dashboard/logout-button";
+"use client";
+
+import { useState } from "react";
+import AddJobModal from "@/components/dashboard/add_job_modal";
+import JobCardList from "@/components/dashboard/job_card_list";
+import type { Job, JobStage } from "@/types/job";
+
+const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
 
 export default function DashboardPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [showForm, setShowForm] = useState(false);
+  const [editingJob, setEditingJob] = useState<Job | null>(null);
+  const [search, setSearch] = useState("");
+  const [stageFilter, setStageFilter] = useState<JobStage | "">("");
+  const [sortBy, setSortBy] = useState<"recent" | "company" | "priority">("recent");
+
+  function handleAddClick() {
+    setEditingJob(null);
+    setShowForm(true);
+  }
+
+  function handleEditClick(job: Job) {
+    setEditingJob(job);
+    setShowForm(true);
+  }
+
+  function handleDelete(id: string) {
+    setJobs((current) => current.filter((job) => job.id !== id));
+  }
+
+  function handleSave(job: Job) {
+    setJobs((current) => {
+      const exists = current.some((j) => j.id === job.id);
+      if (exists) {
+        return current.map((j) => (j.id === job.id ? job : j));
+      }
+      return [job, ...current];
+    });
+    setShowForm(false);
+    setEditingJob(null);
+  }
+
+  function handleCancel() {
+    setShowForm(false);
+    setEditingJob(null);
+  }
+
+  const filtered = jobs
+    .filter((job) => {
+      if (search) {
+        const q = search.toLowerCase();
+        return (
+          job.title.toLowerCase().includes(q) ||
+          job.company.toLowerCase().includes(q)
+        );
+      }
+      return true;
+    })
+    .filter((job) => {
+      if (stageFilter) return job.stage === stageFilter;
+      return true;
+    })
+    .sort((a, b) => {
+      if (sortBy === "company") return a.company.localeCompare(b.company);
+      if (sortBy === "priority") return (b.priority ? 1 : 0) - (a.priority ? 1 : 0);
+      return b.lastActivityDate.localeCompare(a.lastActivityDate);
+    });
+
   return (
-    <main>
-      <p>test</p>
-      <LogoutButton />
-      <div>
-        <h1 className="text-2xl font-semibold text-zinc-50 mb-2">Dashboard</h1>
-        <p className="text-sm text-zinc-400">
-          Your job board will live here.
-        </p>
+    <>
+      {/* Header */}
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-zinc-50">Dashboard</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Track and manage your job applications.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleAddClick}
+          className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+        >
+          Add Job
+        </button>
       </div>
-    </main>
+
+      {/* Toolbar: Search, Filter, Sort */}
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
+        {/* Search */}
+        <div className="relative flex-1">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <input
+            type="text"
+            placeholder="Search jobs..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full bg-zinc-800 border border-zinc-700 rounded-md pl-9 pr-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+          />
+        </div>
+
+        {/* Stage filter */}
+        <select
+          value={stageFilter}
+          onChange={(e) => setStageFilter(e.target.value as JobStage | "")}
+          className="bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+        >
+          <option value="">All stages</option>
+          {STAGES.map((stage) => (
+            <option key={stage} value={stage}>
+              {stage}
+            </option>
+          ))}
+        </select>
+
+        {/* Sort */}
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as "recent" | "company" | "priority")}
+          className="bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+        >
+          <option value="recent">Most recent</option>
+          <option value="company">Company A-Z</option>
+          <option value="priority">Priority first</option>
+        </select>
+      </div>
+
+      {/* Job count */}
+      <p className="mb-4 text-xs text-zinc-500">
+        {filtered.length} {filtered.length === 1 ? "job" : "jobs"}
+        {stageFilter ? ` in ${stageFilter}` : ""}
+        {search ? ` matching "${search}"` : ""}
+      </p>
+
+      {/* Job board */}
+      <JobCardList jobs={filtered} onEdit={handleEditClick} onDelete={handleDelete} />
+
+      {/* Add/Edit modal */}
+      <AddJobModal
+        isOpen={showForm}
+        initialValues={editingJob}
+        onSubmit={handleSave}
+        onClose={handleCancel}
+      />
+    </>
   );
 }

--- a/src/components/dashboard/add_job_modal.tsx
+++ b/src/components/dashboard/add_job_modal.tsx
@@ -21,23 +21,21 @@ export default function AddJobModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
-      <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+      <div className="w-full max-w-2xl bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xl font-semibold text-gray-900">
+          <h2 className="text-lg font-semibold text-zinc-50">
             {initialValues ? "Edit Job" : "Add Job"}
           </h2>
-
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md px-3 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+            className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-50 rounded-md px-2.5 py-1 text-sm"
             aria-label="Close modal"
           >
-            ✕
+            &#x2715;
           </button>
         </div>
-
         <JobForm initialValues={initialValues} onSubmit={onSubmit} onCancel={onClose} />
       </div>
     </div>

--- a/src/components/dashboard/job_card.tsx
+++ b/src/components/dashboard/job_card.tsx
@@ -1,7 +1,4 @@
-import Image from "next/image";
-import deleteIcon from "@/app/icon/Delete_icon.png";
-import editIcon from "@/app/icon/edit.png";
-import type { Job } from "@/types/job";
+import type { Job, JobStage } from "@/types/job";
 
 type JobCardProps = {
   job: Job;
@@ -9,31 +6,43 @@ type JobCardProps = {
   onDelete?: (id: string) => void;
 };
 
+const STAGE_STYLES: Record<JobStage, string> = {
+  Interested: "bg-zinc-900 text-zinc-400",
+  Applied: "bg-blue-950 text-blue-400",
+  Interview: "bg-yellow-950 text-yellow-400",
+  Offer: "bg-green-950 text-green-400",
+  Rejected: "bg-red-950 text-red-400",
+  Archived: "bg-zinc-900 text-zinc-500",
+};
+
 export default function JobCard({ job, onEdit, onDelete }: JobCardProps) {
   return (
-    <div className="rounded-xl border border-gray-200 bg-white p-4 shadow-sm hover:shadow-md transition">
-      {/* Top */}
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">{job.title}</h2>
-          <p className="text-sm text-gray-600">{job.company}</p>
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      {/* Top: Title + Stage */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-medium text-zinc-50 truncate">
+            {job.title}
+          </h2>
+          <p className="text-sm text-zinc-400">{job.company}</p>
         </div>
-
-        <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700">
+        <span
+          className={`shrink-0 rounded-md px-2.5 py-1 text-xs font-medium ${STAGE_STYLES[job.stage]}`}
+        >
           {job.stage}
         </span>
       </div>
 
       {/* Details */}
-      <div className="mt-4 space-y-1 text-sm text-gray-500">
-        {job.location && <p>Location: {job.location}</p>}
+      <div className="mt-4 space-y-1 text-sm text-zinc-500">
+        {job.location && <p>{job.location}</p>}
         <p>Last activity: {job.lastActivityDate}</p>
       </div>
 
-      {/* Bottom */}
+      {/* Bottom: Priority + Actions */}
       <div className="mt-4 flex items-center justify-between">
         {job.priority ? (
-          <span className="rounded-full bg-yellow-100 px-2 py-1 text-xs font-medium text-yellow-800">
+          <span className="bg-yellow-950 text-yellow-400 rounded-md px-2 py-1 text-xs font-medium">
             Priority
           </span>
         ) : (
@@ -45,9 +54,23 @@ export default function JobCard({ job, onEdit, onDelete }: JobCardProps) {
             <button
               type="button"
               onClick={() => onEdit(job)}
-              className="rounded-md border px-3 py-1 text-xs hover:bg-gray-100"
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 rounded-md px-3 py-1 text-xs font-medium"
+              aria-label={`Edit ${job.title}`}
             >
-              <Image src={editIcon} alt="Edit" width={20} height={20} />
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
             </button>
           )}
 
@@ -55,9 +78,23 @@ export default function JobCard({ job, onEdit, onDelete }: JobCardProps) {
             <button
               type="button"
               onClick={() => onDelete(job.id)}
-              className="rounded-md border border-red-300 px-3 py-1 text-xs text-red-600 hover:bg-red-50"
+              className="bg-red-600 hover:bg-red-700 text-zinc-50 rounded-md px-3 py-1 text-xs font-medium"
+              aria-label={`Delete ${job.title}`}
             >
-              <Image src={deleteIcon} alt="Delete" width={20} height={20} />
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              </svg>
             </button>
           )}
         </div>

--- a/src/components/dashboard/job_card_list.tsx
+++ b/src/components/dashboard/job_card_list.tsx
@@ -10,8 +10,26 @@ type JobCardListProps = {
 export default function JobCardList({ jobs, onEdit, onDelete }: JobCardListProps) {
   if (!jobs || jobs.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-gray-300 p-10 text-center text-gray-500">
-        No jobs found.
+      <div className="bg-zinc-900 border border-dashed border-zinc-700 rounded-lg p-10 text-center">
+        <svg
+          className="mx-auto mb-3 text-zinc-600"
+          width="40"
+          height="40"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+          <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+        </svg>
+        <p className="text-sm text-zinc-400">No jobs yet.</p>
+        <p className="mt-1 text-xs text-zinc-500">
+          Click &quot;Add Job&quot; to start tracking your applications.
+        </p>
       </div>
     );
   }

--- a/src/components/dashboard/job_form.tsx
+++ b/src/components/dashboard/job_form.tsx
@@ -11,11 +11,16 @@ type JobFormProps = {
 
 const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
 
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-sm font-medium text-zinc-300";
+
 export default function JobForm({ initialValues, onSubmit, onCancel }: JobFormProps) {
   const [title, setTitle] = useState(initialValues?.title ?? "");
   const [company, setCompany] = useState(initialValues?.company ?? "");
   const [location, setLocation] = useState(initialValues?.location ?? "");
-  const [stage, setStage] = useState<JobStage>(initialValues?.stage ?? ("Interested" as JobStage));
+  const [stage, setStage] = useState<JobStage>(initialValues?.stage ?? "Interested");
   const [lastActivityDate, setLastActivityDate] = useState(
     initialValues?.lastActivityDate ?? new Date().toISOString().slice(0, 10)
   );
@@ -42,85 +47,86 @@ export default function JobForm({ initialValues, onSubmit, onCancel }: JobFormPr
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="title">
+        <label className={labelStyles} htmlFor="title">
           Job Title
         </label>
         <input
           id="title"
           type="text"
           value={title}
-          onChange={(event) => setTitle(event.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          onChange={(e) => setTitle(e.target.value)}
+          className={inputStyles}
           placeholder="Software Engineer Intern"
           required
         />
       </div>
 
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company">
+        <label className={labelStyles} htmlFor="company">
           Company
         </label>
         <input
           id="company"
           type="text"
           value={company}
-          onChange={(event) => setCompany(event.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          onChange={(e) => setCompany(e.target.value)}
+          className={inputStyles}
           placeholder="Google"
           required
         />
       </div>
 
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="location">
+        <label className={labelStyles} htmlFor="location">
           Location
         </label>
         <input
           id="location"
           type="text"
           value={location}
-          onChange={(event) => setLocation(event.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          onChange={(e) => setLocation(e.target.value)}
+          className={inputStyles}
           placeholder="Mountain View, CA"
         />
       </div>
 
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="stage">
+        <label className={labelStyles} htmlFor="stage">
           Stage
         </label>
         <select
           id="stage"
           value={stage}
-          onChange={(event) => setStage(event.target.value as JobStage)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          onChange={(e) => setStage(e.target.value as JobStage)}
+          className={inputStyles}
         >
-          {STAGES.map((jobStage) => (
-            <option key={jobStage} value={jobStage}>
-              {jobStage}
+          {STAGES.map((s) => (
+            <option key={s} value={s}>
+              {s}
             </option>
           ))}
         </select>
       </div>
 
       <div>
-        <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="lastActivityDate">
+        <label className={labelStyles} htmlFor="lastActivityDate">
           Last Activity Date
         </label>
         <input
           id="lastActivityDate"
           type="date"
           value={lastActivityDate}
-          onChange={(event) => setLastActivityDate(event.target.value)}
-          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-500"
+          onChange={(e) => setLastActivityDate(e.target.value)}
+          className={inputStyles}
         />
       </div>
 
-      <label className="flex items-center gap-2 text-sm text-gray-700">
+      <label className="flex items-center gap-2 text-sm text-zinc-300">
         <input
           type="checkbox"
           checked={priority}
-          onChange={(event) => setPriority(event.target.checked)}
+          onChange={(e) => setPriority(e.target.checked)}
+          className="accent-indigo-500"
         />
         Mark as priority
       </label>
@@ -129,13 +135,13 @@ export default function JobForm({ initialValues, onSubmit, onCancel }: JobFormPr
         <button
           type="button"
           onClick={onCancel}
-          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
         >
           Cancel
         </button>
         <button
           type="submit"
-          className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800"
+          className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
         >
           {initialValues ? "Update Job" : "Add Job"}
         </button>


### PR DESCRIPTION
Summary                                                                                                                   
- Rebuilds dashboard page with full skeleton: header, search input, stage filter, sort controls, job count, and job card grid                                                                                                                         - Converts all dashboard components (job card, job list, modal, form) from light theme to dark theme, matching UI/UX         
  standards                                                                                                                    
- Replaces Image icon imports with inline SVGs (removes dependency on src/app/icon/)                                       
- Adds semantic stage badge colors (blue=Applied, yellow=Interview, green=Offer, red=Rejected)

Linked Issue
- Closes #16