### PR TITLE
feat(profile): implement profile page with completion indicator

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,10 +1,67 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { CompletionIndicator } from "@/components/profile/completion-indicator";
+import { IdentitySection } from "@/components/profile/identity-section";
+import { SummarySection } from "@/components/profile/summary-section";
+import { ExperienceSection } from "@/components/profile/experience-section";
+import { EducationSection } from "@/components/profile/education-section";
+import { SkillsSection } from "@/components/profile/skills-section";
+import { CareerPreferencesSection } from "@/components/profile/career-preferences-section";
+import type { ProfileData, CompletionField } from "@/types/profile";
+
+const EMPTY_PROFILE: ProfileData = {
+  targetRoles: [],
+  targetLocations: [],
+  experiences: [],
+  educations: [],
+  skills: [],
+};
+
+function getCompletionFields(profile: ProfileData): CompletionField[] {
+  return [
+    { label: "First name", complete: !!profile.firstName },
+    { label: "Last name", complete: !!profile.lastName },
+    { label: "Email", complete: !!profile.email },
+    { label: "Phone", complete: !!profile.phone },
+    { label: "Location", complete: !!profile.location },
+    { label: "Headline", complete: !!profile.headline },
+    { label: "Summary", complete: !!profile.summary },
+    { label: "Experience", complete: profile.experiences.length > 0 },
+    { label: "Education", complete: profile.educations.length > 0 },
+    { label: "Skills", complete: profile.skills.length > 0 },
+    { label: "Target roles", complete: profile.targetRoles.length > 0 },
+    { label: "Work mode", complete: !!profile.workModePreference },
+  ];
+}
+
 export default function ProfilePage() {
+  const [profile, setProfile] = useState<ProfileData>(EMPTY_PROFILE);
+
+  function handleUpdate(fields: Partial<ProfileData>) {
+    setProfile((prev) => ({ ...prev, ...fields }));
+  }
+
+  const completionFields = useMemo(() => getCompletionFields(profile), [profile]);
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold text-zinc-50 mb-2">Profile</h1>
-      <p className="text-sm text-zinc-400">
-        Your profile will live here.
-      </p>
-    </div>
+    <>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-zinc-50">Profile</h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          Build your profile to tailor resumes and cover letters.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <CompletionIndicator fields={completionFields} />
+        <IdentitySection profile={profile} onUpdate={handleUpdate} />
+        <SummarySection profile={profile} onUpdate={handleUpdate} />
+        <ExperienceSection experiences={profile.experiences} />
+        <EducationSection educations={profile.educations} />
+        <SkillsSection skills={profile.skills} />
+        <CareerPreferencesSection profile={profile} onUpdate={handleUpdate} />
+      </div>
+    </>
   );
 }

--- a/src/components/profile/career-preferences-section.tsx
+++ b/src/components/profile/career-preferences-section.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState } from "react";
+import type { ProfileData } from "@/types/profile";
+
+type CareerPreferencesSectionProps = {
+  profile: ProfileData;
+  onUpdate: (fields: Partial<ProfileData>) => void;
+};
+
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
+
+const WORK_MODES = ["Remote", "Hybrid", "On-site", "Flexible"];
+
+export function CareerPreferencesSection({ profile, onUpdate }: CareerPreferencesSectionProps) {
+  const [editing, setEditing] = useState(false);
+  const [targetRoles, setTargetRoles] = useState(profile.targetRoles.join(", "));
+  const [targetLocations, setTargetLocations] = useState(profile.targetLocations.join(", "));
+  const [workMode, setWorkMode] = useState(profile.workModePreference ?? "");
+  const [salary, setSalary] = useState(profile.salaryPreference?.toString() ?? "");
+
+  function handleSave() {
+    onUpdate({
+      targetRoles: targetRoles
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+      targetLocations: targetLocations
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+      workModePreference: workMode || undefined,
+      salaryPreference: salary ? Number.parseInt(salary, 10) : undefined,
+    });
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setTargetRoles(profile.targetRoles.join(", "));
+    setTargetLocations(profile.targetLocations.join(", "));
+    setWorkMode(profile.workModePreference ?? "");
+    setSalary(profile.salaryPreference?.toString() ?? "");
+    setEditing(false);
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Career Preferences</h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="space-y-4">
+          <div>
+            <label className={labelStyles} htmlFor="targetRoles">
+              Target Roles (comma-separated)
+            </label>
+            <input
+              id="targetRoles"
+              type="text"
+              value={targetRoles}
+              onChange={(e) => setTargetRoles(e.target.value)}
+              className={inputStyles}
+              placeholder="Software Engineer, Frontend Developer"
+            />
+          </div>
+          <div>
+            <label className={labelStyles} htmlFor="targetLocations">
+              Target Locations (comma-separated)
+            </label>
+            <input
+              id="targetLocations"
+              type="text"
+              value={targetLocations}
+              onChange={(e) => setTargetLocations(e.target.value)}
+              className={inputStyles}
+              placeholder="New York, San Francisco, Remote"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelStyles} htmlFor="workMode">Work Mode</label>
+              <select
+                id="workMode"
+                value={workMode}
+                onChange={(e) => setWorkMode(e.target.value)}
+                className={inputStyles}
+              >
+                <option value="">Select preference</option>
+                {WORK_MODES.map((mode) => (
+                  <option key={mode} value={mode}>{mode}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className={labelStyles} htmlFor="salary">
+                Salary Preference ($/year)
+              </label>
+              <input
+                id="salary"
+                type="number"
+                value={salary}
+                onChange={(e) => setSalary(e.target.value)}
+                className={inputStyles}
+                placeholder="85000"
+                min="0"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-xs text-zinc-500">Target Roles</p>
+            <p className="text-zinc-50">
+              {profile.targetRoles.length > 0
+                ? profile.targetRoles.join(", ")
+                : <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Target Locations</p>
+            <p className="text-zinc-50">
+              {profile.targetLocations.length > 0
+                ? profile.targetLocations.join(", ")
+                : <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Work Mode</p>
+            <p className="text-zinc-50">
+              {profile.workModePreference || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Salary Preference</p>
+            <p className="text-zinc-50">
+              {profile.salaryPreference
+                ? `$${profile.salaryPreference.toLocaleString()}/year`
+                : <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/completion-indicator.tsx
+++ b/src/components/profile/completion-indicator.tsx
@@ -1,0 +1,88 @@
+import type { CompletionField } from "@/types/profile";
+import { cn } from "@/utils/cn";
+
+type CompletionIndicatorProps = {
+  fields: CompletionField[];
+};
+
+export function CompletionIndicator({ fields }: CompletionIndicatorProps) {
+  const completed = fields.filter((f) => f.complete).length;
+  const total = fields.length;
+  const percent = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">
+          Profile Completion
+        </h2>
+        <span
+          className={cn(
+            "text-2xl font-semibold",
+            percent === 100 ? "text-green-400" : percent >= 50 ? "text-yellow-400" : "text-red-400"
+          )}
+        >
+          {percent}%
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full h-2 bg-zinc-800 rounded-full overflow-hidden mb-4">
+        <div
+          className={cn(
+            "h-full rounded-full transition-all",
+            percent === 100
+              ? "bg-green-400"
+              : percent >= 50
+                ? "bg-yellow-400"
+                : "bg-red-400"
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      {/* Checklist */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {fields.map((field) => (
+          <div key={field.label} className="flex items-center gap-2 text-sm">
+            {field.complete ? (
+              <svg
+                className="shrink-0 text-green-400"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+            ) : (
+              <svg
+                className="shrink-0 text-zinc-600"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+              </svg>
+            )}
+            <span className={field.complete ? "text-zinc-300" : "text-zinc-500"}>
+              {field.label}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/education-section.tsx
+++ b/src/components/profile/education-section.tsx
@@ -1,0 +1,44 @@
+import type { Education } from "@/types/profile";
+
+type EducationSectionProps = {
+  educations: Education[];
+};
+
+export function EducationSection({ educations }: EducationSectionProps) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Education</h2>
+        <button
+          type="button"
+          className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium opacity-50 cursor-not-allowed"
+          disabled
+        >
+          Add
+        </button>
+      </div>
+
+      {educations.length === 0 ? (
+        <p className="text-sm text-zinc-500">No education added yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {educations.map((edu) => (
+            <div key={edu.id} className="border-l-2 border-zinc-700 pl-4">
+              <p className="text-sm font-medium text-zinc-50">{edu.institution}</p>
+              {(edu.degree || edu.fieldOfStudy) && (
+                <p className="text-sm text-zinc-400">
+                  {[edu.degree, edu.fieldOfStudy].filter(Boolean).join(" in ")}
+                </p>
+              )}
+              {(edu.startDate || edu.endDate) && (
+                <p className="text-xs text-zinc-500">
+                  {edu.startDate ?? "?"} &mdash; {edu.endDate ?? "?"}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/experience-section.tsx
+++ b/src/components/profile/experience-section.tsx
@@ -1,0 +1,40 @@
+import type { Experience } from "@/types/profile";
+
+type ExperienceSectionProps = {
+  experiences: Experience[];
+};
+
+export function ExperienceSection({ experiences }: ExperienceSectionProps) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Experience</h2>
+        <button
+          type="button"
+          className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium opacity-50 cursor-not-allowed"
+          disabled
+        >
+          Add
+        </button>
+      </div>
+
+      {experiences.length === 0 ? (
+        <p className="text-sm text-zinc-500">No experience added yet.</p>
+      ) : (
+        <div className="space-y-4">
+          {experiences.map((exp) => (
+            <div key={exp.id} className="border-l-2 border-zinc-700 pl-4">
+              <p className="text-sm font-medium text-zinc-50">{exp.title}</p>
+              {exp.organization && (
+                <p className="text-sm text-zinc-400">{exp.organization}</p>
+              )}
+              <p className="text-xs text-zinc-500">
+                {exp.startDate ?? "?"} &mdash; {exp.isCurrent ? "Present" : exp.endDate ?? "?"}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/identity-section.tsx
+++ b/src/components/profile/identity-section.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState } from "react";
+import type { ProfileData } from "@/types/profile";
+
+type IdentitySectionProps = {
+  profile: ProfileData;
+  onUpdate: (fields: Partial<ProfileData>) => void;
+};
+
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
+
+export function IdentitySection({ profile, onUpdate }: IdentitySectionProps) {
+  const [editing, setEditing] = useState(false);
+  const [firstName, setFirstName] = useState(profile.firstName ?? "");
+  const [lastName, setLastName] = useState(profile.lastName ?? "");
+  const [email, setEmail] = useState(profile.email ?? "");
+  const [phone, setPhone] = useState(profile.phone ?? "");
+  const [location, setLocation] = useState(profile.location ?? "");
+
+  function handleSave() {
+    onUpdate({
+      firstName: firstName.trim() || undefined,
+      lastName: lastName.trim() || undefined,
+      email: email.trim() || undefined,
+      phone: phone.trim() || undefined,
+      location: location.trim() || undefined,
+    });
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setFirstName(profile.firstName ?? "");
+    setLastName(profile.lastName ?? "");
+    setEmail(profile.email ?? "");
+    setPhone(profile.phone ?? "");
+    setLocation(profile.location ?? "");
+    setEditing(false);
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Identity & Contact</h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelStyles} htmlFor="firstName">First Name</label>
+              <input
+                id="firstName"
+                type="text"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                className={inputStyles}
+                placeholder="Jane"
+              />
+            </div>
+            <div>
+              <label className={labelStyles} htmlFor="lastName">Last Name</label>
+              <input
+                id="lastName"
+                type="text"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                className={inputStyles}
+                placeholder="Doe"
+              />
+            </div>
+          </div>
+          <div>
+            <label className={labelStyles} htmlFor="profileEmail">Email</label>
+            <input
+              id="profileEmail"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className={inputStyles}
+              placeholder="jane@example.com"
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className={labelStyles} htmlFor="phone">Phone</label>
+              <input
+                id="phone"
+                type="tel"
+                value={phone}
+                onChange={(e) => setPhone(e.target.value)}
+                className={inputStyles}
+                placeholder="(555) 123-4567"
+              />
+            </div>
+            <div>
+              <label className={labelStyles} htmlFor="profileLocation">Location</label>
+              <input
+                id="profileLocation"
+                type="text"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                className={inputStyles}
+                placeholder="New York, NY"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-xs text-zinc-500">Name</p>
+            <p className="text-zinc-50">
+              {profile.firstName || profile.lastName
+                ? `${profile.firstName ?? ""} ${profile.lastName ?? ""}`.trim()
+                : <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Email</p>
+            <p className="text-zinc-50">
+              {profile.email || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Phone</p>
+            <p className="text-zinc-50">
+              {profile.phone || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Location</p>
+            <p className="text-zinc-50">
+              {profile.location || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/skills-section.tsx
+++ b/src/components/profile/skills-section.tsx
@@ -1,0 +1,40 @@
+import type { Skill } from "@/types/profile";
+
+type SkillsSectionProps = {
+  skills: Skill[];
+};
+
+export function SkillsSection({ skills }: SkillsSectionProps) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Skills</h2>
+        <button
+          type="button"
+          className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium opacity-50 cursor-not-allowed"
+          disabled
+        >
+          Add
+        </button>
+      </div>
+
+      {skills.length === 0 ? (
+        <p className="text-sm text-zinc-500">No skills added yet.</p>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {skills.map((skill) => (
+            <span
+              key={skill.id}
+              className="bg-zinc-800 border border-zinc-700 text-zinc-300 rounded-md px-3 py-1 text-xs font-medium"
+            >
+              {skill.name}
+              {skill.proficiency && (
+                <span className="ml-1 text-zinc-500">({skill.proficiency})</span>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/summary-section.tsx
+++ b/src/components/profile/summary-section.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import type { ProfileData } from "@/types/profile";
+
+type SummarySectionProps = {
+  profile: ProfileData;
+  onUpdate: (fields: Partial<ProfileData>) => void;
+};
+
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
+
+export function SummarySection({ profile, onUpdate }: SummarySectionProps) {
+  const [editing, setEditing] = useState(false);
+  const [headline, setHeadline] = useState(profile.headline ?? "");
+  const [summary, setSummary] = useState(profile.summary ?? "");
+
+  function handleSave() {
+    onUpdate({
+      headline: headline.trim() || undefined,
+      summary: summary.trim() || undefined,
+    });
+    setEditing(false);
+  }
+
+  function handleCancel() {
+    setHeadline(profile.headline ?? "");
+    setSummary(profile.summary ?? "");
+    setEditing(false);
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-zinc-50">Professional Summary</h2>
+        {!editing && (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+          >
+            Edit
+          </button>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="space-y-4">
+          <div>
+            <label className={labelStyles} htmlFor="headline">Headline</label>
+            <input
+              id="headline"
+              type="text"
+              value={headline}
+              onChange={(e) => setHeadline(e.target.value)}
+              className={inputStyles}
+              placeholder="Full Stack Developer | React & Node.js"
+            />
+          </div>
+          <div>
+            <label className={labelStyles} htmlFor="summary">Summary</label>
+            <textarea
+              id="summary"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              className={`${inputStyles} min-h-[120px] resize-y`}
+              placeholder="Brief overview of your professional background and goals..."
+              rows={5}
+            />
+          </div>
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3 text-sm">
+          <div>
+            <p className="text-xs text-zinc-500">Headline</p>
+            <p className="text-zinc-50">
+              {profile.headline || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs text-zinc-500">Summary</p>
+            <p className="text-zinc-50 whitespace-pre-wrap">
+              {profile.summary || <span className="text-zinc-600">Not set</span>}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,52 @@
+export type Experience = {
+  id: string;
+  type: "EMPLOYMENT" | "PROJECT";
+  title: string;
+  organization?: string;
+  startDate?: string;
+  endDate?: string;
+  isCurrent: boolean;
+  description?: string;
+  bullets: string[];
+};
+
+export type Education = {
+  id: string;
+  institution: string;
+  degree?: string;
+  fieldOfStudy?: string;
+  startDate?: string;
+  endDate?: string;
+  gpa?: string;
+  honors?: string;
+};
+
+export type Skill = {
+  id: string;
+  name: string;
+  category?: string;
+  proficiency?: string;
+};
+
+export type ProfileData = {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  phone?: string;
+  location?: string;
+  professionalLinks?: Record<string, string>;
+  headline?: string;
+  summary?: string;
+  targetRoles: string[];
+  targetLocations: string[];
+  workModePreference?: string;
+  salaryPreference?: number;
+  experiences: Experience[];
+  educations: Education[];
+  skills: Skill[];
+};
+
+export type CompletionField = {
+  label: string;
+  complete: boolean;
+};


### PR DESCRIPTION
## Summary
  - Adds `ProfileCompletionIndicator` component — progress bar + 12-item checklist tracking which profile fields are filled  
  (color-coded: red <50%, yellow 50-99%, green 100%)
  - Adds editable section cards: Identity & Contact, Professional Summary, Career Preferences (inline edit with save/cancel) 
  - Adds read-only section cards: Experience, Education, Skills (with empty states, Add buttons disabled until API is wired) 
  - Adds `ProfileData` type definitions in `src/types/profile.ts` matching the Prisma schema
  - All components follow dark theme from UI/UX standards (`bg-zinc-900`, `border-zinc-700`, indigo accents)
  - Client-side state management — ready to wire to API when profile endpoints are built

  ## Linked Issue
  Closes #21