### PR TITLE
feat(settings): implement settings page baseline with account, notifi…

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,10 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { AccountSection } from "@/components/settings/account-section";
+import { NotificationSection } from "@/components/settings/notification-section";
+import { AppPreferencesSection } from "@/components/settings/app-preferences-section";
+
 export default function SettingsPage() {
+  const [email, setEmail] = useState("");
+
+  const [notifications, setNotifications] = useState({
+    emailJobUpdates: true,
+    emailDeadlineReminders: true,
+    emailWeeklySummary: false,
+  });
+
+  const [appPreferences, setAppPreferences] = useState({
+    defaultJobStage: "Interested",
+    showArchived: false,
+  });
+
+  function handleToggleNotification(key: keyof typeof notifications) {
+    setNotifications((prev) => ({ ...prev, [key]: !prev[key] }));
+  }
+
+  function handleUpdatePreference(key: string, value: string | boolean) {
+    setAppPreferences((prev) => ({ ...prev, [key]: value }));
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold text-zinc-50 mb-2">Settings</h1>
-      <p className="text-sm text-zinc-400">
-        Account settings will live here.
-      </p>
-    </div>
+    <>
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold text-zinc-50">Settings</h1>
+        <p className="mt-1 text-sm text-zinc-400">
+          Manage your account, notifications, and preferences.
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <AccountSection
+          email={email}
+          onUpdateEmail={setEmail}
+          onUpdatePassword={() => {}}
+        />
+        <NotificationSection
+          preferences={notifications}
+          onToggle={handleToggleNotification}
+        />
+        <AppPreferencesSection
+          preferences={appPreferences}
+          onUpdate={handleUpdatePreference}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+
+type AccountSectionProps = {
+  email: string;
+  onUpdateEmail: (email: string) => void;
+  onUpdatePassword: (current: string, newPassword: string) => void;
+};
+
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
+
+export function AccountSection({ email, onUpdateEmail, onUpdatePassword }: AccountSectionProps) {
+  const [editingEmail, setEditingEmail] = useState(false);
+  const [editingPassword, setEditingPassword] = useState(false);
+  const [newEmail, setNewEmail] = useState(email);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+
+  function handleSaveEmail() {
+    if (newEmail.trim()) {
+      onUpdateEmail(newEmail.trim());
+    }
+    setEditingEmail(false);
+  }
+
+  function handleCancelEmail() {
+    setNewEmail(email);
+    setEditingEmail(false);
+  }
+
+  function handleSavePassword() {
+    setPasswordError("");
+    if (!currentPassword) {
+      setPasswordError("Current password is required.");
+      return;
+    }
+    if (newPassword.length < 8) {
+      setPasswordError("New password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setPasswordError("Passwords do not match.");
+      return;
+    }
+    onUpdatePassword(currentPassword, newPassword);
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setEditingPassword(false);
+  }
+
+  function handleCancelPassword() {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setPasswordError("");
+    setEditingPassword(false);
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-zinc-50 mb-6">Account</h2>
+
+      {/* Email */}
+      <div className="mb-6 pb-6 border-b border-zinc-800">
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm font-medium text-zinc-300">Email Address</p>
+          {!editingEmail && (
+            <button
+              type="button"
+              onClick={() => setEditingEmail(true)}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-3 py-1.5 rounded-md text-xs font-medium"
+            >
+              Change
+            </button>
+          )}
+        </div>
+
+        {editingEmail ? (
+          <div className="space-y-3">
+            <div>
+              <label className={labelStyles} htmlFor="newEmail">New Email</label>
+              <input
+                id="newEmail"
+                type="email"
+                value={newEmail}
+                onChange={(e) => setNewEmail(e.target.value)}
+                className={inputStyles}
+                placeholder="new@example.com"
+              />
+            </div>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCancelEmail}
+                className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveEmail}
+                className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-zinc-50">{email || <span className="text-zinc-600">Not set</span>}</p>
+        )}
+      </div>
+
+      {/* Password */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-sm font-medium text-zinc-300">Password</p>
+          {!editingPassword && (
+            <button
+              type="button"
+              onClick={() => setEditingPassword(true)}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-3 py-1.5 rounded-md text-xs font-medium"
+            >
+              Change
+            </button>
+          )}
+        </div>
+
+        {editingPassword ? (
+          <div className="space-y-3">
+            {passwordError && (
+              <p className="text-sm text-red-400">{passwordError}</p>
+            )}
+            <div>
+              <label className={labelStyles} htmlFor="currentPassword">Current Password</label>
+              <input
+                id="currentPassword"
+                type="password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+                className={inputStyles}
+                placeholder="Enter current password"
+              />
+            </div>
+            <div>
+              <label className={labelStyles} htmlFor="newPassword">New Password</label>
+              <input
+                id="newPassword"
+                type="password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                className={inputStyles}
+                placeholder="At least 8 characters"
+              />
+            </div>
+            <div>
+              <label className={labelStyles} htmlFor="confirmNewPassword">Confirm New Password</label>
+              <input
+                id="confirmNewPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className={inputStyles}
+                placeholder="Confirm new password"
+              />
+            </div>
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleCancelPassword}
+                className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSavePassword}
+                className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+              >
+                Update Password
+              </button>
+            </div>
+          </div>
+        ) : (
+          <p className="text-sm text-zinc-500">••••••••</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/app-preferences-section.tsx
+++ b/src/components/settings/app-preferences-section.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+type AppPreferencesSectionProps = {
+  preferences: {
+    defaultJobStage: string;
+    showArchived: boolean;
+  };
+  onUpdate: (key: string, value: string | boolean) => void;
+};
+
+const inputStyles =
+  "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
+
+const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
+
+const JOB_STAGES = ["Interested", "Applied", "Interview", "Offer"];
+
+export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesSectionProps) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-zinc-50 mb-4">Application Preferences</h2>
+
+      <div className="space-y-4">
+        <div>
+          <label className={labelStyles} htmlFor="defaultStage">
+            Default stage for new jobs
+          </label>
+          <select
+            id="defaultStage"
+            value={preferences.defaultJobStage}
+            onChange={(e) => onUpdate("defaultJobStage", e.target.value)}
+            className={inputStyles}
+          >
+            {JOB_STAGES.map((stage) => (
+              <option key={stage} value={stage}>{stage}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex items-center justify-between py-3">
+          <div>
+            <p className="text-sm font-medium text-zinc-300">Show archived jobs</p>
+            <p className="text-xs text-zinc-500">Display archived jobs on the dashboard.</p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={preferences.showArchived}
+            onClick={() => onUpdate("showArchived", !preferences.showArchived)}
+            className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent cursor-pointer transition-colors ${
+              preferences.showArchived ? "bg-indigo-500" : "bg-zinc-700"
+            }`}
+          >
+            <span
+              className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-zinc-50 shadow-sm transition-transform ${
+                preferences.showArchived ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/notification-section.tsx
+++ b/src/components/settings/notification-section.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+type NotificationSectionProps = {
+  preferences: {
+    emailJobUpdates: boolean;
+    emailDeadlineReminders: boolean;
+    emailWeeklySummary: boolean;
+  };
+  onToggle: (key: keyof NotificationSectionProps["preferences"]) => void;
+};
+
+function Toggle({ checked, onChange, label, description }: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div>
+        <p className="text-sm font-medium text-zinc-300">{label}</p>
+        <p className="text-xs text-zinc-500">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent cursor-pointer transition-colors ${
+          checked ? "bg-indigo-500" : "bg-zinc-700"
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-zinc-50 shadow-sm transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export function NotificationSection({ preferences, onToggle }: NotificationSectionProps) {
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <h2 className="text-lg font-semibold text-zinc-50 mb-4">Notifications</h2>
+
+      <div className="divide-y divide-zinc-800">
+        <Toggle
+          checked={preferences.emailJobUpdates}
+          onChange={() => onToggle("emailJobUpdates")}
+          label="Job status updates"
+          description="Get notified when a job's stage changes."
+        />
+        <Toggle
+          checked={preferences.emailDeadlineReminders}
+          onChange={() => onToggle("emailDeadlineReminders")}
+          label="Deadline reminders"
+          description="Receive reminders before upcoming application deadlines."
+        />
+        <Toggle
+          checked={preferences.emailWeeklySummary}
+          onChange={() => onToggle("emailWeeklySummary")}
+          label="Weekly summary"
+          description="A weekly digest of your job search activity."
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary                                                                                                                   
- Adds AccountSection — change email and password with inline edit, client-side validation (min 8 chars, confirm match)      
- Adds NotificationSection — toggle switches for job updates, deadline reminders, weekly summary                             
- Adds AppPreferencesSection — default job stage selector, show archived jobs toggle                                         
- All components follow dark theme (bg-zinc-900, border-zinc-700, indigo accents)                                            
- Client-side state — ready to wire to API when settings endpoints are built                                               

  ## Linked Issue
  Closes #15