### PR TITLE
feat(settings): add styled sign out button to settings page

### DIFF
--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { LogoutButton } from "@/components/dashboard/logout-button";
 import { AccountSection } from "@/components/settings/account-section";
 import { AppPreferencesSection } from "@/components/settings/app-preferences-section";
 import { NotificationSection } from "@/components/settings/notification-section";
@@ -40,6 +41,10 @@ export default function SettingsPage() {
         <AccountSection email={email} onUpdateEmail={setEmail} onUpdatePassword={() => {}} />
         <NotificationSection preferences={notifications} onToggle={handleToggleNotification} />
         <AppPreferencesSection preferences={appPreferences} onUpdate={handleUpdatePreference} />
+      </div>
+
+      <div className="mt-8 pt-6 border-t border-zinc-800">
+        <LogoutButton />
       </div>
     </>
   );

--- a/src/components/dashboard/logout-button.tsx
+++ b/src/components/dashboard/logout-button.tsx
@@ -32,11 +32,24 @@ export function LogoutButton() {
   }
 
   return (
-    <div>
-      {error && <p>{error}</p>}
-      <button onClick={handleLogout} type="button" disabled={loading}>
-        {loading ? "Signing out..." : "Sign out"}
-      </button>
+    <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-50">Sign Out</h2>
+          <p className="mt-1 text-sm text-zinc-400">
+            End your current session and return to the login page.
+          </p>
+        </div>
+        <button
+          onClick={handleLogout}
+          type="button"
+          disabled={loading}
+          className="bg-red-500/10 border border-red-500/30 text-red-400 hover:bg-red-500/20 hover:text-red-300 hover:border-red-500/50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer px-4 py-2 rounded-md text-sm font-medium transition-colors"
+        >
+          {loading ? "Signing out..." : "Sign out"}
+        </button>
+      </div>
+      {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
     </div>
   );
 }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -7,7 +7,6 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-
 // cn() is a utility already in the project (src/utils/cn.ts).
 // It merges Tailwind classes cleanly so we can write conditional styles.
 import { cn } from "@/utils/cn";


### PR DESCRIPTION
## Summary
- Restyle `LogoutButton` as a card with a red-tinted button, hover states, cursor pointer, and error messaging
- Place the sign out section at the bottom of `/settings` below a divider
- Revert sidebar back to original placeholder (logout is no longer there)