### PR TITLE
refactor(schema): remove unused Auth.js adapter models

### DIFF
--- a/prisma/migrations/20260405202501_remove_authjs_models/migration.sql
+++ b/prisma/migrations/20260405202501_remove_authjs_models/migration.sql
@@ -1,0 +1,35 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Account` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `Session` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `VerificationToken` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "public"."Account" DROP CONSTRAINT "Account_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Document" DROP CONSTRAINT "Document_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Job" DROP CONSTRAINT "Job_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Profile" DROP CONSTRAINT "Profile_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "public"."Session" DROP CONSTRAINT "Session_userId_fkey";
+
+-- DropTable
+DROP TABLE "public"."Account";
+
+-- DropTable
+DROP TABLE "public"."Session";
+
+-- DropTable
+DROP TABLE "public"."User";
+
+-- DropTable
+DROP TABLE "public"."VerificationToken";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,64 +10,6 @@ datasource db {
 }
 
 // ---------------------------------------------------------------------------
-// Auth.js adapter models — do not modify field names or types
-// ---------------------------------------------------------------------------
-
-model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String    @unique
-  emailVerified DateTime?
-  image         String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-
-  accounts  Account[]
-  sessions  Session[]
-  profile   Profile?
-  jobs      Job[]
-  documents Document[]
-}
-
-model Account {
-  userId            String
-  type              String
-  provider          String
-  providerAccountId String
-  refresh_token     String?
-  access_token      String?
-  expires_at        Int?
-  token_type        String?
-  scope             String?
-  id_token          String?
-  session_state     String?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-  @@id([provider, providerAccountId])
-}
-
-model Session {
-  sessionToken String   @unique
-  userId       String
-  expires      DateTime
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-}
-
-model VerificationToken {
-  identifier String
-  token      String
-  expires    DateTime
-
-  @@id([identifier, token])
-}
-
-// ---------------------------------------------------------------------------
 // App models
 // ---------------------------------------------------------------------------
 
@@ -90,7 +32,6 @@ model Profile {
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
 
-  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   experiences Experience[]
   educations  Education[]
   skills      Skill[]
@@ -160,7 +101,6 @@ model Job {
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt
 
-  user          User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   stageHistory  JobStageHistory[]
   activities    JobActivity[]
   documentLinks JobDocumentLink[]
@@ -203,7 +143,6 @@ model Document {
   createdAt DateTime       @default(now())
   updatedAt DateTime       @updatedAt
 
-  user     User              @relation(fields: [userId], references: [id], onDelete: Cascade)
   versions DocumentVersion[]
   jobLinks JobDocumentLink[]
 }


### PR DESCRIPTION
## Summary
- Removes Auth.js adapter models (`User`, `Account`, `Session`, `VerificationToken`) from Prisma schema — these were never used since auth is handled by Supabase Auth
- Drops FK constraints from `Job`, `Profile`, and `Document` so `userId` stores the Supabase UUID as a plain string
- Fixes `Job_userId_fkey` foreign key violation that prevented creating jobs

## Test plan
- [x] `bun run type-check` passes
- [x] All 58 tests pass
- [x] Migration applies cleanly
- [ ] Teammates run `bun prisma migrate dev` after pulling