### PR TITLE
feat(seeding): add demo seed and clean scripts for Sprint 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     "postinstall": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:generate": "prisma generate",
-    "prisma:studio": "prisma studio"
+    "prisma:studio": "prisma studio",
+    "db:seed": "bun run src/scripts/seed.ts",
+    "db:clean": "bun run src/scripts/clean-seed.ts"
+  },
+  "prisma": {
+    "seed": "bun run src/scripts/seed.ts"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,jsonc}": [

--- a/src/scripts/clean-seed.ts
+++ b/src/scripts/clean-seed.ts
@@ -1,0 +1,23 @@
+import { prisma } from "@/services/prisma";
+
+const USER_ID = "86bef9c8-5d2c-40bb-aeb2-8580cecb4eb5";
+
+async function main() {
+  console.log("🧹 Cleaning demo jobs for user:", USER_ID);
+
+  const result = await prisma.job.deleteMany({
+    where: { userId: USER_ID },
+  });
+
+  console.log(`  ✅ Deleted ${result.count} jobs`);
+  console.log("\n✨ Clean complete!");
+}
+
+main()
+  .catch((e) => {
+    console.error("Clean failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,0 +1,81 @@
+import { prisma } from "@/services/prisma";
+
+const USER_ID = "86bef9c8-5d2c-40bb-aeb2-8580cecb4eb5";
+
+const DEMO_JOBS = [
+  {
+    title: "Senior Software Engineer",
+    company: "TechCorp",
+    location: "San Francisco, CA",
+    stage: "APPLIED" as const,
+    priority: true,
+    description: "Building scalable backend systems",
+    applicationDate: new Date("2024-03-15"),
+  },
+  {
+    title: "Full Stack Developer",
+    company: "InnovateTech",
+    location: "Remote",
+    stage: "INTERVIEW" as const,
+    priority: true,
+    description: "Full stack development with React and Node.js",
+    applicationDate: new Date("2024-03-20"),
+  },
+  {
+    title: "Frontend Engineer",
+    company: "WebSolutions",
+    location: "New York, NY",
+    stage: "INTERESTED" as const,
+    priority: false,
+    description: "Building modern web applications",
+    applicationDate: new Date("2024-03-25"),
+  },
+  {
+    title: "Backend Developer",
+    company: "DataDriven",
+    location: "Austin, TX",
+    stage: "OFFER" as const,
+    priority: true,
+    description: "Developing high-performance APIs",
+    applicationDate: new Date("2024-03-10"),
+  },
+  {
+    title: "Software Engineer II",
+    company: "StartupXYZ",
+    location: "Remote",
+    stage: "APPLIED" as const,
+    priority: false,
+    description: "Early-stage startup, equity opportunity",
+    applicationDate: new Date("2024-03-28"),
+  },
+];
+
+async function main() {
+  console.log("🌱 Seeding demo jobs for user:", USER_ID);
+
+  for (const jobData of DEMO_JOBS) {
+    try {
+      const job = await prisma.job.create({
+        data: {
+          userId: USER_ID,
+          ...jobData,
+          lastActivityAt: jobData.applicationDate || new Date(),
+        },
+      });
+      console.log(`  ✅ Created: ${job.title} at ${job.company}`);
+    } catch (error) {
+      console.error(`  ❌ Failed to create ${jobData.title}:`, error);
+    }
+  }
+
+  console.log("\n✨ Seed complete!");
+}
+
+main()
+  .catch((e) => {
+    console.error("Seed failed:", e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## Summary

- Add `src/scripts/seed.ts` to create 5 demo jobs for Sprint 1 demo user
- Add `src/scripts/clean-seed.ts` to remove demo jobs
- Add npm scripts `db:seed` and `db:clean` for easy access
- Configure Prisma seed command for automatic seeding

## Changes

- Created seed script with 5 realistic job entries across different stages (Interested, Applied, Interview, Offer)
- Added clean script to remove all jobs for the demo user
- Updated `package.json` with convenience scripts and Prisma seed config

## Demo Readiness

These scripts provide quick setup for Sprint 1 demo:
```bash
bun run db:seed   # Creates 5 demo jobs
bun run db:clean  # Removes all demo jobs
```

All jobs include: title, company, location, stage, priority, description, and application date.