### PR TITLE
feat(dashboard): expand job search to keyword matching across all fields

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { Select } from "@/components/ui/select";
 import { DashboardSkeleton } from "@/components/ui/skeletons/dashboard-skeleton";
 import { showToast } from "@/components/ui/toast";
 import type { Job, JobStage } from "@/types/job";
+import { searchJobs } from "@/utils/search-jobs";
 
 const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
 
@@ -148,14 +149,7 @@ export default function DashboardPage() {
     setEditingJob(null);
   }
 
-  const filtered = jobs
-    .filter((job) => {
-      if (search) {
-        const q = search.toLowerCase();
-        return job.title.toLowerCase().includes(q) || job.company.toLowerCase().includes(q);
-      }
-      return true;
-    })
+  const filtered = searchJobs(jobs, search)
     .filter((job) => {
       if (stageFilter) return job.stage === stageFilter;
       return true;

--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -28,6 +28,8 @@ export function toJobResponse(job: PrismaJob): Job {
     stage: STAGE_PRISMA_TO_UI[job.stage] ?? "Interested",
     lastActivityDate: (job.lastActivityAt ?? job.createdAt).toISOString().slice(0, 10),
     location: job.location ?? undefined,
+    description: job.description ?? undefined,
+    customNotes: job.customNotes ?? undefined,
     priority: job.priority,
   };
 }

--- a/src/tests/utils/search-jobs.test.ts
+++ b/src/tests/utils/search-jobs.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { Job } from "@/types/job";
+import { searchJobs } from "@/utils/search-jobs";
+
+const jobs: Job[] = [
+  {
+    id: "1",
+    title: "Frontend Engineer",
+    company: "Acme Corp",
+    stage: "Applied",
+    lastActivityDate: "2024-01-15",
+    location: "San Francisco, CA",
+    description: "Build React applications with TypeScript",
+    customNotes: "Recruiter reached out via LinkedIn",
+    priority: true,
+  },
+  {
+    id: "2",
+    title: "Backend Developer",
+    company: "Globex Inc",
+    stage: "Interview",
+    lastActivityDate: "2024-01-14",
+    location: "New York, NY",
+    description: "Design REST APIs and microservices",
+    customNotes: "Need to prepare system design",
+    priority: false,
+  },
+  {
+    id: "3",
+    title: "Full Stack Engineer",
+    company: "Initech",
+    stage: "Offer",
+    lastActivityDate: "2024-01-13",
+    location: "Remote",
+    description: "Work across the entire stack",
+    priority: false,
+  },
+];
+
+describe("searchJobs", () => {
+  it("matches by title", () => {
+    expect(searchJobs(jobs, "frontend")).toHaveLength(1);
+    expect(searchJobs(jobs, "frontend")[0].id).toBe("1");
+  });
+
+  it("matches by company", () => {
+    expect(searchJobs(jobs, "globex")).toHaveLength(1);
+    expect(searchJobs(jobs, "globex")[0].id).toBe("2");
+  });
+
+  it("matches by location", () => {
+    expect(searchJobs(jobs, "remote")).toHaveLength(1);
+    expect(searchJobs(jobs, "remote")[0].id).toBe("3");
+  });
+
+  it("matches by description", () => {
+    expect(searchJobs(jobs, "react")).toHaveLength(1);
+    expect(searchJobs(jobs, "react")[0].id).toBe("1");
+  });
+
+  it("matches by customNotes", () => {
+    expect(searchJobs(jobs, "linkedin")).toHaveLength(1);
+    expect(searchJobs(jobs, "linkedin")[0].id).toBe("1");
+  });
+
+  it("returns all jobs when query is empty", () => {
+    expect(searchJobs(jobs, "")).toHaveLength(3);
+  });
+
+  it("is case-insensitive", () => {
+    expect(searchJobs(jobs, "ACME")).toHaveLength(1);
+    expect(searchJobs(jobs, "ENGINEER")).toHaveLength(2);
+  });
+
+  it("returns empty array when no matches", () => {
+    expect(searchJobs(jobs, "nonexistent")).toHaveLength(0);
+  });
+
+  it("matches partial words", () => {
+    expect(searchJobs(jobs, "glob")).toHaveLength(1);
+  });
+});

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -7,5 +7,7 @@ export type Job = {
   stage: JobStage;
   lastActivityDate: string;
   location?: string;
+  description?: string;
+  customNotes?: string;
   priority?: boolean;
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { cn } from "./cn";
+export { searchJobs } from "./search-jobs";

--- a/src/utils/search-jobs.ts
+++ b/src/utils/search-jobs.ts
@@ -1,0 +1,13 @@
+import type { Job } from "@/types/job";
+
+export function searchJobs(jobs: Job[], query: string): Job[] {
+  if (!query) return jobs;
+
+  const q = query.toLowerCase();
+
+  return jobs.filter((job) => {
+    const fields = [job.title, job.company, job.location, job.description, job.customNotes];
+
+    return fields.some((field) => field?.toLowerCase().includes(q));
+  });
+}


### PR DESCRIPTION
## Summary

- Extract client-side job search into reusable `searchJobs()` utility (`src/utils/search-jobs.ts`)
- Expand search beyond title/company to include **location**, **description**, and **customNotes**
- Surface `description` and `customNotes` fields in the `Job` type and `toJobResponse` mapper (already present in Prisma schema but previously unused)
- 9 unit tests covering all searchable fields, case-insensitivity, partial matches, and empty query

Closes #61