### PR TITLE
fix(prisma): add missing migration file 20260407175547_bun_prisma

### DIFF
--- a/prisma/migrations/20260407175547_bun_prisma/migration.sql
+++ b/prisma/migrations/20260407175547_bun_prisma/migration.sql
@@ -1,0 +1,1 @@
+-- AlreadyApplied


### PR DESCRIPTION
## Summary
- Adds the missing migration file `20260407175547_bun_prisma` that was applied to the database but never committed to the repo
- Empty placeholder migration since the DB and schema are already in sync — this just resolves the `missing from local migrations directory` error for everyone on the team