### PR TITLE
S2-024: Implement document save from job context

### DIFF
--- a/src/app/api/documents/[id]/route.ts
+++ b/src/app/api/documents/[id]/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { getDocumentById, softDeleteDocument, updateDocumentContent } from "@/services/documents";
+import { UpdateDocumentContentSchema } from "@/types/schemas";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+
+      const doc = await getDocumentById(id, user.id);
+      if (!doc) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      return NextResponse.json(doc, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function PUT(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+      const data = await validateBody(request, UpdateDocumentContentSchema);
+
+      const doc = await updateDocumentContent(id, user.id, data.content);
+      if (!doc) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      logger.info("Document updated", { userId: user.id, documentId: id });
+      return NextResponse.json(doc, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function DELETE(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+
+      const deleted = await softDeleteDocument(id, user.id);
+      if (!deleted) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      logger.info("Document deleted", { userId: user.id, documentId: id });
+      return new NextResponse(null, { status: 204 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/app/api/documents/[id]/versions/route.ts
+++ b/src/app/api/documents/[id]/versions/route.ts
@@ -1,0 +1,48 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { createDocumentVersion, getDocumentVersions } from "@/services/documents";
+import { UpdateDocumentContentSchema } from "@/types/schemas";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+
+      const versions = await getDocumentVersions(id, user.id);
+      if (!versions) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      return NextResponse.json(versions, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+      const data = await validateBody(request, UpdateDocumentContentSchema);
+
+      const version = await createDocumentVersion(id, user.id, data.content);
+      if (!version) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      logger.info("Document version created", { userId: user.id, documentId: id });
+      return NextResponse.json(version, { status: 201 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/app/api/documents/route.ts
+++ b/src/app/api/documents/route.ts
@@ -1,0 +1,41 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { createDocument, getDocumentsByUserId, toDocumentResponse } from "@/services/documents";
+import { CreateDocumentSchema } from "@/types/schemas";
+
+export async function GET(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const docs = await getDocumentsByUserId(user.id);
+      return NextResponse.json(docs, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function POST(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const data = await validateBody(request, CreateDocumentSchema);
+
+      const { doc, version } = await createDocument(user.id, data);
+
+      logger.info("Document created", {
+        userId: user.id,
+        documentId: doc.id,
+        type: data.type,
+      });
+
+      return NextResponse.json(toDocumentResponse(doc, version), { status: 201 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/app/api/jobs/[id]/documents/route.ts
+++ b/src/app/api/jobs/[id]/documents/route.ts
@@ -1,0 +1,57 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { getDocumentsForJob, linkDocumentToJob } from "@/services/documents";
+import { LinkDocumentToJobSchema } from "@/types/schemas";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+
+      const docs = await getDocumentsForJob(id, user.id);
+      if (!docs) {
+        return NextResponse.json({ error: "Job not found" }, { status: 404 });
+      }
+
+      return NextResponse.json(docs, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id: jobId } = await context.params;
+      const data = await validateBody(request, LinkDocumentToJobSchema);
+
+      const link = await linkDocumentToJob(jobId, data.documentId, data.documentVersionId, user.id);
+
+      if (!link) {
+        return NextResponse.json({ error: "Job, document, or version not found" }, { status: 404 });
+      }
+
+      logger.info("Document linked to job", {
+        userId: user.id,
+        jobId,
+        documentId: data.documentId,
+      });
+
+      return NextResponse.json(
+        { id: link.id, linkedAt: link.linkedAt.toISOString() },
+        { status: 201 }
+      );
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -1,0 +1,214 @@
+import type { Document, DocumentType, DocumentVersion } from "@prisma/client";
+import { prisma } from "@/services/prisma";
+import type { DocumentResponse, DocumentVersionResponse } from "@/types/document";
+
+type CreateDocumentInput = {
+  type: DocumentType;
+  name: string;
+  content?: string;
+  jobId?: string;
+};
+
+export function toDocumentResponse(
+  doc: Document,
+  latestVersion: DocumentVersion
+): DocumentResponse {
+  return {
+    id: doc.id,
+    type: doc.type,
+    name: doc.name,
+    status: doc.status,
+    content: latestVersion.content ?? undefined,
+    versionNumber: latestVersion.versionNumber,
+    createdAt: doc.createdAt.toISOString(),
+    updatedAt: doc.updatedAt.toISOString(),
+  };
+}
+
+export function toVersionResponse(v: DocumentVersion): DocumentVersionResponse {
+  return {
+    id: v.id,
+    versionNumber: v.versionNumber,
+    content: v.content ?? undefined,
+    createdAt: v.createdAt.toISOString(),
+  };
+}
+
+export async function createDocument(userId: string, input: CreateDocumentInput) {
+  return prisma.$transaction(async (tx) => {
+    const doc = await tx.document.create({
+      data: {
+        userId,
+        type: input.type,
+        name: input.name,
+        status: "DRAFT",
+      },
+    });
+
+    const version = await tx.documentVersion.create({
+      data: {
+        documentId: doc.id,
+        versionNumber: 1,
+        content: input.content ?? null,
+      },
+    });
+
+    if (input.jobId) {
+      const job = await tx.job.findFirst({ where: { id: input.jobId, userId } });
+      if (job) {
+        await tx.jobDocumentLink.create({
+          data: {
+            jobId: input.jobId,
+            documentId: doc.id,
+            documentVersionId: version.id,
+          },
+        });
+      }
+    }
+
+    return { doc, version };
+  });
+}
+
+export async function getDocumentsByUserId(userId: string) {
+  const docs = await prisma.document.findMany({
+    where: { userId, isDeleted: false },
+    include: {
+      versions: { orderBy: { versionNumber: "desc" }, take: 1 },
+    },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return docs.filter((d) => d.versions.length > 0).map((d) => toDocumentResponse(d, d.versions[0]));
+}
+
+export async function getDocumentById(id: string, userId: string) {
+  const doc = await prisma.document.findFirst({
+    where: { id, userId, isDeleted: false },
+    include: {
+      versions: { orderBy: { versionNumber: "desc" }, take: 1 },
+    },
+  });
+
+  if (!doc || doc.versions.length === 0) return null;
+  return toDocumentResponse(doc, doc.versions[0]);
+}
+
+export async function updateDocumentContent(id: string, userId: string, content: string) {
+  const doc = await prisma.document.findFirst({
+    where: { id, userId, isDeleted: false },
+    include: {
+      versions: { orderBy: { versionNumber: "desc" }, take: 1 },
+    },
+  });
+
+  if (!doc) return null;
+
+  const nextVersion = doc.versions.length > 0 ? doc.versions[0].versionNumber + 1 : 1;
+
+  return prisma.$transaction(async (tx) => {
+    const version = await tx.documentVersion.create({
+      data: {
+        documentId: id,
+        versionNumber: nextVersion,
+        content,
+      },
+    });
+
+    const updated = await tx.document.update({
+      where: { id },
+      data: { updatedAt: new Date() },
+    });
+
+    return toDocumentResponse(updated, version);
+  });
+}
+
+export async function softDeleteDocument(id: string, userId: string): Promise<boolean> {
+  const doc = await prisma.document.findFirst({
+    where: { id, userId, isDeleted: false },
+  });
+  if (!doc) return false;
+
+  await prisma.document.update({
+    where: { id },
+    data: { isDeleted: true, deletedAt: new Date() },
+  });
+  return true;
+}
+
+export async function getDocumentVersions(documentId: string, userId: string) {
+  const doc = await prisma.document.findFirst({
+    where: { id: documentId, userId, isDeleted: false },
+  });
+  if (!doc) return null;
+
+  const versions = await prisma.documentVersion.findMany({
+    where: { documentId },
+    orderBy: { versionNumber: "desc" },
+  });
+  return versions.map(toVersionResponse);
+}
+
+export async function createDocumentVersion(documentId: string, userId: string, content: string) {
+  const doc = await prisma.document.findFirst({
+    where: { id: documentId, userId, isDeleted: false },
+    include: {
+      versions: { orderBy: { versionNumber: "desc" }, take: 1 },
+    },
+  });
+
+  if (!doc) return null;
+
+  const nextVersion = doc.versions.length > 0 ? doc.versions[0].versionNumber + 1 : 1;
+
+  const version = await prisma.documentVersion.create({
+    data: {
+      documentId,
+      versionNumber: nextVersion,
+      content,
+    },
+  });
+
+  return toVersionResponse(version);
+}
+
+export async function linkDocumentToJob(
+  jobId: string,
+  documentId: string,
+  documentVersionId: string,
+  userId: string
+) {
+  const [job, doc, version] = await Promise.all([
+    prisma.job.findFirst({ where: { id: jobId, userId } }),
+    prisma.document.findFirst({ where: { id: documentId, userId, isDeleted: false } }),
+    prisma.documentVersion.findFirst({ where: { id: documentVersionId, documentId } }),
+  ]);
+
+  if (!job || !doc || !version) return null;
+
+  return prisma.jobDocumentLink.create({
+    data: { jobId, documentId, documentVersionId },
+  });
+}
+
+export async function getDocumentsForJob(jobId: string, userId: string) {
+  const job = await prisma.job.findFirst({ where: { id: jobId, userId } });
+  if (!job) return null;
+
+  const links = await prisma.jobDocumentLink.findMany({
+    where: { jobId },
+    include: {
+      document: true,
+      documentVersion: true,
+    },
+    orderBy: { linkedAt: "desc" },
+  });
+
+  return links
+    .filter((l) => !l.document.isDeleted)
+    .map((l) => ({
+      ...toDocumentResponse(l.document, l.documentVersion),
+      linkedAt: l.linkedAt.toISOString(),
+    }));
+}

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,0 +1,20 @@
+export type DocumentType = "RESUME" | "COVER_LETTER" | "OTHER";
+export type DocumentStatus = "DRAFT" | "READY" | "ARCHIVED";
+
+export type DocumentResponse = {
+  id: string;
+  type: DocumentType;
+  name: string;
+  status: DocumentStatus;
+  content?: string;
+  versionNumber: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DocumentVersionResponse = {
+  id: string;
+  versionNumber: number;
+  content?: string;
+  createdAt: string;
+};

--- a/src/types/schemas/document.ts
+++ b/src/types/schemas/document.ts
@@ -1,0 +1,21 @@
+import { z } from "zod/v4";
+
+export const DocumentTypeSchema = z.enum(["RESUME", "COVER_LETTER", "OTHER"]);
+
+export const DocumentStatusSchema = z.enum(["DRAFT", "READY", "ARCHIVED"]);
+
+export const CreateDocumentSchema = z.object({
+  type: DocumentTypeSchema,
+  name: z.string().trim().min(1, "Name is required").max(200),
+  content: z.string().optional(),
+  jobId: z.string().optional(),
+});
+
+export const UpdateDocumentContentSchema = z.object({
+  content: z.string().min(1, "Content is required"),
+});
+
+export const LinkDocumentToJobSchema = z.object({
+  documentId: z.string().min(1, "Document ID is required"),
+  documentVersionId: z.string().min(1, "Document version ID is required"),
+});

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -1,3 +1,9 @@
 export { CredentialsSchema } from "./auth";
+export {
+  CreateDocumentSchema,
+  DocumentTypeSchema,
+  LinkDocumentToJobSchema,
+  UpdateDocumentContentSchema,
+} from "./document";
 export { CreateJobSchema, JobStageSchema, UpdateJobSchema } from "./job";
 export { ProfilePatchSchema } from "./profile";


### PR DESCRIPTION
## Summary
- Add document CRUD service with versioning (auto-incrementing version numbers) and soft-delete
- Create RESTful API routes for documents (`/api/documents`, `/api/documents/[id]`, `/api/documents/[id]/versions`)
- Add job-document linking endpoint (`/api/jobs/[id]/documents`) with ownership verification
- Add Zod validation schemas for all document request bodies

## Test plan
- [ ] POST /api/documents creates document with initial version
- [ ] GET /api/documents returns user's non-deleted documents
- [ ] PUT /api/documents/[id] creates new version with incremented version number
- [ ] DELETE /api/documents/[id] soft-deletes (sets isDeleted + deletedAt)
- [ ] POST /api/jobs/[id]/documents links document to job after ownership check
- [ ] All endpoints return 401 for unauthenticated requests
- [ ] All endpoints return 404 for resources not owned by user