### PR TITLE
S2-021: Implement AI resume draft from profile + job

### DIFF
--- a/src/app/api/ai/resume/route.ts
+++ b/src/app/api/ai/resume/route.ts
@@ -1,0 +1,55 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ApiError, handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { generateResumeDraft } from "@/services/ai";
+import { createDocument, toDocumentResponse } from "@/services/documents";
+import { prisma } from "@/services/prisma";
+import { getProfile } from "@/services/profile";
+import { GenerateDocumentSchema } from "@/types/schemas";
+
+export async function POST(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { jobId } = await validateBody(request, GenerateDocumentSchema);
+
+      const profile = await getProfile(user.id);
+      if (!profile) {
+        throw new ApiError(400, "Profile is required to generate a resume");
+      }
+
+      const job = await prisma.job.findFirst({
+        where: { id: jobId, userId: user.id },
+      });
+      if (!job) {
+        throw new ApiError(404, "Job not found");
+      }
+
+      const result = await generateResumeDraft(profile, {
+        title: job.title,
+        company: job.company,
+        description: job.description ?? undefined,
+      });
+
+      const { doc, version } = await createDocument(user.id, {
+        type: "RESUME",
+        name: `Resume - ${job.company}`,
+        content: result.content,
+        jobId,
+      });
+
+      logger.info("AI resume draft generated", {
+        userId: user.id,
+        jobId,
+        documentId: doc.id,
+      });
+
+      return NextResponse.json(toDocumentResponse(doc, version), { status: 201 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/components/documents/generate-resume-button.tsx
+++ b/src/components/documents/generate-resume-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Props = {
+  jobId: string;
+  onGenerated?: (documentId: string) => void;
+};
+
+export function GenerateResumeButton({ jobId, onGenerated }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/ai/resume", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId }),
+      });
+
+      if (res.status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to generate resume");
+        return;
+      }
+
+      const doc = await res.json();
+      onGenerated?.(doc.id);
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={handleGenerate}
+        disabled={loading}
+        className="bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium"
+      >
+        {loading ? "Generating..." : "Generate Resume"}
+      </button>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -1,0 +1,160 @@
+import type { ProfileData } from "@/types/profile";
+
+type JobContext = {
+  title: string;
+  company: string;
+  description?: string;
+};
+
+type GenerateResult = {
+  content: string;
+};
+
+/**
+ * Generates a resume draft using profile data and job context.
+ *
+ * Placeholder implementation — returns a structured Markdown resume.
+ * Swap in a real AI provider (OpenAI, Anthropic, etc.) when decided.
+ */
+export async function generateResumeDraft(
+  profile: ProfileData,
+  job: JobContext
+): Promise<GenerateResult> {
+  const name = [profile.firstName, profile.lastName].filter(Boolean).join(" ") || "Your Name";
+  const contact = [profile.email, profile.phone, profile.location].filter(Boolean).join(" | ");
+
+  const lines: string[] = [];
+  lines.push(`# ${name}`);
+  if (contact) lines.push(contact);
+  lines.push("");
+
+  if (profile.summary) {
+    lines.push("## Summary");
+    lines.push(profile.summary);
+    lines.push("");
+  }
+
+  lines.push(`> Tailored for **${job.title}** at **${job.company}**`);
+  lines.push("");
+
+  if (profile.experiences.length > 0) {
+    lines.push("## Experience");
+    for (const exp of profile.experiences) {
+      const dates = [exp.startDate, exp.isCurrent ? "Present" : exp.endDate]
+        .filter(Boolean)
+        .join(" - ");
+      lines.push(`### ${exp.title}${exp.organization ? ` — ${exp.organization}` : ""}`);
+      if (dates) lines.push(dates);
+      if (exp.description) lines.push(exp.description);
+      lines.push("");
+    }
+  }
+
+  if (profile.educations.length > 0) {
+    lines.push("## Education");
+    for (const edu of profile.educations) {
+      const degree = [edu.degree, edu.fieldOfStudy].filter(Boolean).join(", ");
+      lines.push(`### ${edu.institution}`);
+      if (degree) lines.push(degree);
+      const dates = [edu.startDate, edu.endDate].filter(Boolean).join(" - ");
+      if (dates) lines.push(dates);
+      if (edu.gpa) lines.push(`GPA: ${edu.gpa}`);
+      lines.push("");
+    }
+  }
+
+  if (profile.skills.length > 0) {
+    lines.push("## Skills");
+    lines.push(profile.skills.map((s) => s.name).join(", "));
+    lines.push("");
+  }
+
+  return { content: lines.join("\n") };
+}
+
+/**
+ * Generates a cover letter draft using profile data and job context.
+ *
+ * Placeholder implementation — returns a structured cover letter template.
+ */
+export async function generateCoverLetterDraft(
+  profile: ProfileData,
+  job: JobContext
+): Promise<GenerateResult> {
+  const name = [profile.firstName, profile.lastName].filter(Boolean).join(" ") || "Your Name";
+
+  const lines: string[] = [];
+  lines.push(name);
+  if (profile.email) lines.push(profile.email);
+  if (profile.phone) lines.push(profile.phone);
+  if (profile.location) lines.push(profile.location);
+  lines.push("");
+  lines.push(`Dear Hiring Manager at ${job.company},`);
+  lines.push("");
+  lines.push(
+    `I am writing to express my interest in the **${job.title}** position at **${job.company}**.${
+      profile.summary ? ` ${profile.summary}` : ""
+    }`
+  );
+  lines.push("");
+
+  if (profile.experiences.length > 0) {
+    const recent = profile.experiences[0];
+    lines.push(
+      `In my role as ${recent.title}${recent.organization ? ` at ${recent.organization}` : ""}, I developed skills and experience directly relevant to this position.${
+        recent.description ? ` ${recent.description}` : ""
+      }`
+    );
+    lines.push("");
+  }
+
+  if (job.description) {
+    lines.push(
+      "Based on the job description, I believe my background aligns well with your team's needs. I am eager to bring my skills to this role and contribute to your organization's goals."
+    );
+    lines.push("");
+  }
+
+  lines.push(
+    "I would welcome the opportunity to discuss how my experience can contribute to your team. Thank you for considering my application."
+  );
+  lines.push("");
+  lines.push("Sincerely,");
+  lines.push(name);
+
+  return { content: lines.join("\n") };
+}
+
+type RewriteInput = {
+  content: string;
+  instruction: string;
+};
+
+/**
+ * Rewrites/improves document content based on an instruction.
+ *
+ * Placeholder implementation — prepends the instruction as a note
+ * and returns lightly restructured content. Replace with AI call.
+ */
+export async function rewriteContent(input: RewriteInput): Promise<GenerateResult> {
+  const { content, instruction } = input;
+
+  // Placeholder: apply simple transformations based on common instructions
+  let rewritten = content;
+
+  const lower = instruction.toLowerCase();
+  if (lower.includes("concise") || lower.includes("shorter") || lower.includes("brief")) {
+    // Trim lines that are empty or very short filler
+    rewritten = content
+      .split("\n")
+      .filter((line) => line.trim().length > 0)
+      .join("\n");
+  } else if (lower.includes("formal") || lower.includes("professional")) {
+    rewritten = content.replace(/!\s*/g, ". ").replace(/\.\.\./g, ".");
+  }
+
+  // Always prepend instruction note so user knows what was requested
+  rewritten = `<!-- Rewrite instruction: ${instruction} -->\n${rewritten}`;
+
+  return { content: rewritten };
+}

--- a/src/types/schemas/document.ts
+++ b/src/types/schemas/document.ts
@@ -19,3 +19,12 @@ export const LinkDocumentToJobSchema = z.object({
   documentId: z.string().min(1, "Document ID is required"),
   documentVersionId: z.string().min(1, "Document version ID is required"),
 });
+
+export const GenerateDocumentSchema = z.object({
+  jobId: z.string().min(1, "Job ID is required"),
+});
+
+export const RewriteContentSchema = z.object({
+  documentId: z.string().min(1, "Document ID is required"),
+  instruction: z.string().trim().min(1, "Instruction is required").max(500),
+});

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -2,7 +2,9 @@ export { CredentialsSchema } from "./auth";
 export {
   CreateDocumentSchema,
   DocumentTypeSchema,
+  GenerateDocumentSchema,
   LinkDocumentToJobSchema,
+  RewriteContentSchema,
   UpdateDocumentContentSchema,
 } from "./document";
 export { CreateJobSchema, JobStageSchema, UpdateJobSchema } from "./job";


### PR DESCRIPTION
## Summary
- Add AI service abstraction (`src/services/ai.ts`) with placeholder template-based resume generation
- Create `POST /api/ai/resume` endpoint that fetches user profile + job data and generates a tailored resume draft
- Add `GenerateResumeButton` component for job detail pages
- Add Zod schemas for AI generation requests (`GenerateDocumentSchema`, `RewriteContentSchema`)

## Notes
AI provider is TBD — the placeholder generates structured Markdown resumes using profile fields. The service interface is ready for any provider swap.

## Test plan
- [ ] POST /api/ai/resume with valid jobId creates a document with resume content
- [ ] Returns 400 if user has no profile
- [ ] Returns 404 if job not found or not owned by user
- [ ] Returns 401 for unauthenticated requests
- [ ] GenerateResumeButton shows loading state and handles errors