### PR TITLE
S2-022: Implement AI cover letter draft from profile + job

### DIFF
--- a/src/app/api/ai/cover-letter/route.ts
+++ b/src/app/api/ai/cover-letter/route.ts
@@ -1,0 +1,55 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { ApiError, handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { generateCoverLetterDraft } from "@/services/ai";
+import { createDocument, toDocumentResponse } from "@/services/documents";
+import { prisma } from "@/services/prisma";
+import { getProfile } from "@/services/profile";
+import { GenerateDocumentSchema } from "@/types/schemas";
+
+export async function POST(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { jobId } = await validateBody(request, GenerateDocumentSchema);
+
+      const profile = await getProfile(user.id);
+      if (!profile) {
+        throw new ApiError(400, "Profile is required to generate a cover letter");
+      }
+
+      const job = await prisma.job.findFirst({
+        where: { id: jobId, userId: user.id },
+      });
+      if (!job) {
+        throw new ApiError(404, "Job not found");
+      }
+
+      const result = await generateCoverLetterDraft(profile, {
+        title: job.title,
+        company: job.company,
+        description: job.description ?? undefined,
+      });
+
+      const { doc, version } = await createDocument(user.id, {
+        type: "COVER_LETTER",
+        name: `Cover Letter - ${job.company}`,
+        content: result.content,
+        jobId,
+      });
+
+      logger.info("AI cover letter draft generated", {
+        userId: user.id,
+        jobId,
+        documentId: doc.id,
+      });
+
+      return NextResponse.json(toDocumentResponse(doc, version), { status: 201 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/components/documents/generate-cover-letter-button.tsx
+++ b/src/components/documents/generate-cover-letter-button.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type Props = {
+  jobId: string;
+  onGenerated?: (documentId: string) => void;
+};
+
+export function GenerateCoverLetterButton({ jobId, onGenerated }: Props) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch("/api/ai/cover-letter", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jobId }),
+      });
+
+      if (res.status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to generate cover letter");
+        return;
+      }
+
+      const doc = await res.json();
+      onGenerated?.(doc.id);
+    } catch {
+      setError("Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={handleGenerate}
+        disabled={loading}
+        className="bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium"
+      >
+        {loading ? "Generating..." : "Generate Cover Letter"}
+      </button>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `POST /api/ai/cover-letter` endpoint for generating cover letter drafts
- Add `GenerateCoverLetterButton` component for job detail pages
- Uses the same AI service abstraction and document save pipeline as resume generation

## Test plan
- [ ] POST /api/ai/cover-letter with valid jobId creates a COVER_LETTER document
- [ ] Returns 400 if user has no profile
- [ ] Returns 404 if job not found or not owned by user
- [ ] Returns 401 for unauthenticated requests