### PR TITLE
S2-025: Implement dashboard metrics with stage counts

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import AddJobModal from "@/components/dashboard/add-job-modal";
 import JobCardList from "@/components/dashboard/job-card-list";
+import { MetricsPanel } from "@/components/dashboard/metrics-panel";
 import { ConfirmDeleteModal } from "@/components/ui/confirm-delete-modal";
 import { Select } from "@/components/ui/select";
 import { DashboardSkeleton } from "@/components/ui/skeletons/dashboard-skeleton";
@@ -197,6 +198,9 @@ export default function DashboardPage() {
           Add Job
         </button>
       </div>
+
+      {/* Metrics */}
+      <MetricsPanel />
 
       {/* Toolbar: Search, Filter, Sort */}
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">

--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -1,0 +1,17 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import { requireAuth } from "@/lib/requireAuth";
+import { getDashboardMetrics } from "@/services/metrics";
+
+export async function GET(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const metrics = await getDashboardMetrics(user.id);
+      return NextResponse.json(metrics, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/components/dashboard/metrics-panel.tsx
+++ b/src/components/dashboard/metrics-panel.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type DashboardMetrics = {
+  stageCounts: Record<string, number>;
+  totalJobs: number;
+  responseRate: number;
+  averageTimeToResponse: number | null;
+  activeApplications: number;
+};
+
+export function MetricsPanel() {
+  const router = useRouter();
+  const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/metrics")
+      .then((res) => {
+        if (res.status === 401) {
+          router.push("/login");
+          return null;
+        }
+        if (!res.ok) return null;
+        return res.json();
+      })
+      .then((data) => {
+        if (data) setMetrics(data);
+      })
+      .finally(() => setLoading(false));
+  }, [router]);
+
+  if (loading) {
+    const skeletonKeys = ["total", "active", "rate", "avg"];
+    return (
+      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {skeletonKeys.map((key) => (
+          <div
+            key={key}
+            className="h-20 animate-pulse rounded-lg border border-zinc-700 bg-zinc-800/50"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!metrics || metrics.totalJobs === 0) return null;
+
+  const cards = [
+    { label: "Total Jobs", value: metrics.totalJobs },
+    { label: "Active", value: metrics.activeApplications },
+    {
+      label: "Response Rate",
+      value: `${metrics.responseRate}%`,
+    },
+    {
+      label: "Avg Response",
+      value: metrics.averageTimeToResponse !== null ? `${metrics.averageTimeToResponse}d` : "N/A",
+    },
+  ];
+
+  return (
+    <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+      {cards.map((card) => (
+        <div key={card.label} className="rounded-lg border border-zinc-700 bg-zinc-800/50 p-4">
+          <p className="text-xs text-zinc-400">{card.label}</p>
+          <p className="mt-1 text-xl font-semibold text-zinc-50">{card.value}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -1,0 +1,99 @@
+import { STAGE_PRISMA_TO_UI } from "@/constants/job-stages";
+import { prisma } from "@/services/prisma";
+
+export type DashboardMetrics = {
+  stageCounts: Record<string, number>;
+  totalJobs: number;
+  responseRate: number;
+  averageTimeToResponse: number | null;
+  activeApplications: number;
+};
+
+export async function getDashboardMetrics(userId: string): Promise<DashboardMetrics> {
+  const jobs = await prisma.job.findMany({ where: { userId } });
+
+  // Stage counts (using UI labels)
+  const stageCounts: Record<string, number> = {};
+  for (const job of jobs) {
+    const uiStage = STAGE_PRISMA_TO_UI[job.stage] ?? job.stage;
+    stageCounts[uiStage] = (stageCounts[uiStage] ?? 0) + 1;
+  }
+
+  // Active applications: not Rejected or Archived
+  const activeApplications = jobs.filter(
+    (j) => j.stage !== "REJECTED" && j.stage !== "ARCHIVED"
+  ).length;
+
+  // Response rate: % of APPLIED jobs that progressed past APPLIED
+  const appliedJobIds = jobs.filter((j) => j.stage !== "INTERESTED").map((j) => j.id);
+
+  let responseRate = 0;
+  let averageTimeToResponse: number | null = null;
+
+  if (appliedJobIds.length > 0) {
+    // Find jobs that have stage history showing movement from APPLIED to another stage
+    const stageHistories = await prisma.jobStageHistory.findMany({
+      where: {
+        jobId: { in: appliedJobIds },
+        fromStage: "APPLIED",
+        toStage: { not: "APPLIED" },
+      },
+      orderBy: { changedAt: "asc" },
+    });
+
+    // Get the set of jobs that had a response (moved past APPLIED)
+    const respondedJobIds = new Set(stageHistories.map((h) => h.jobId));
+    responseRate =
+      appliedJobIds.length > 0
+        ? Math.round((respondedJobIds.size / appliedJobIds.length) * 100)
+        : 0;
+
+    // Average time to response: days from APPLIED entry to next stage
+    if (stageHistories.length > 0) {
+      const appliedEntries = await prisma.jobStageHistory.findMany({
+        where: {
+          jobId: { in: Array.from(respondedJobIds) },
+          toStage: "APPLIED",
+        },
+        orderBy: { changedAt: "asc" },
+      });
+
+      const appliedDateByJob = new Map<string, Date>();
+      for (const entry of appliedEntries) {
+        if (!appliedDateByJob.has(entry.jobId)) {
+          appliedDateByJob.set(entry.jobId, entry.changedAt);
+        }
+      }
+
+      let totalDays = 0;
+      let count = 0;
+
+      // Use the earliest response for each job
+      const firstResponseByJob = new Map<string, Date>();
+      for (const h of stageHistories) {
+        if (!firstResponseByJob.has(h.jobId)) {
+          firstResponseByJob.set(h.jobId, h.changedAt);
+        }
+      }
+
+      for (const [jobId, responseDate] of firstResponseByJob) {
+        const appliedDate = appliedDateByJob.get(jobId);
+        if (appliedDate) {
+          const diffMs = responseDate.getTime() - appliedDate.getTime();
+          totalDays += diffMs / (1000 * 60 * 60 * 24);
+          count++;
+        }
+      }
+
+      averageTimeToResponse = count > 0 ? Math.round((totalDays / count) * 10) / 10 : null;
+    }
+  }
+
+  return {
+    stageCounts,
+    totalJobs: jobs.length,
+    responseRate,
+    averageTimeToResponse,
+    activeApplications,
+  };
+}


### PR DESCRIPTION
## Summary
- Add metrics service computing stage counts, response rate, avg time-to-response, and active applications
- Create `GET /api/metrics` endpoint returning computed metrics for the authenticated user
- Add `MetricsPanel` component with 4 metric cards (Total Jobs, Active, Response Rate, Avg Response)
- Integrate MetricsPanel into dashboard page above the search toolbar

## Test plan
- [ ] GET /api/metrics returns correct stage counts
- [ ] Response rate handles zero-applied case (no division by zero)
- [ ] Average time-to-response returns null when no data
- [ ] MetricsPanel shows skeleton loading state
- [ ] MetricsPanel hides when user has no jobs
- [ ] Returns 401 for unauthenticated requests