### PR TITLE
feat: persist user settings to database

### DIFF
--- a/prisma/migrations/20260413233229_add_user_settings/migration.sql
+++ b/prisma/migrations/20260413233229_add_user_settings/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "UserSettings" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "preferences" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserSettings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserSettings_userId_key" ON "UserSettings"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,14 @@ model JobDocumentLink {
   @@unique([jobId, documentVersionId])
 }
 
+model UserSettings {
+  id          String   @id @default(cuid())
+  userId      String   @unique
+  preferences Json     @default("{}")
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}
+
 // ---------------------------------------------------------------------------
 // Enums
 // ---------------------------------------------------------------------------

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,46 +1,72 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { LogoutButton } from "@/components/dashboard/logout-button";
 import { AccountSection } from "@/components/settings/account-section";
 import { AppPreferencesSection } from "@/components/settings/app-preferences-section";
-import { NotificationSection } from "@/components/settings/notification-section";
+import { showToast } from "@/components/ui/toast";
+import type { UserPreferences } from "@/types/settings";
+import { DEFAULT_PREFERENCES } from "@/types/settings";
 
 export default function SettingsPage() {
-  const [email, setEmail] = useState("");
+  const [preferences, setPreferences] = useState<UserPreferences>(DEFAULT_PREFERENCES);
+  const [loading, setLoading] = useState(true);
 
-  const [notifications, setNotifications] = useState({
-    emailJobUpdates: true,
-    emailDeadlineReminders: true,
-    emailWeeklySummary: false,
-  });
+  useEffect(() => {
+    fetch("/api/settings")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: UserPreferences) => setPreferences(data))
+      .catch(() => showToast("Failed to load settings", "error"))
+      .finally(() => setLoading(false));
+  }, []);
 
-  const [appPreferences, setAppPreferences] = useState({
-    defaultJobStage: "Interested",
-    showArchived: false,
-  });
+  const updatePreference = useCallback(
+    async <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => {
+      const res = await fetch("/api/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ [key]: value }),
+      });
+      if (res.ok) {
+        const updated: UserPreferences = await res.json();
+        setPreferences(updated);
+      } else {
+        showToast("Failed to save setting", "error");
+      }
+    },
+    []
+  );
 
-  function handleToggleNotification(key: keyof typeof notifications) {
-    setNotifications((prev) => ({ ...prev, [key]: !prev[key] }));
-  }
-
-  function handleUpdatePreference(key: string, value: string | boolean) {
-    setAppPreferences((prev) => ({ ...prev, [key]: value }));
+  if (loading) {
+    return (
+      <>
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-zinc-50">Settings</h1>
+          <p className="mt-1 text-sm text-zinc-400">
+            Manage your account, notifications, and preferences.
+          </p>
+        </div>
+        <div className="text-sm text-zinc-500">Loading...</div>
+      </>
+    );
   }
 
   return (
     <>
       <div className="mb-8">
         <h1 className="text-2xl font-semibold text-zinc-50">Settings</h1>
-        <p className="mt-1 text-sm text-zinc-400">
-          Manage your account, notifications, and preferences.
-        </p>
+        <p className="mt-1 text-sm text-zinc-400">Manage your account and preferences.</p>
       </div>
 
       <div className="space-y-8">
-        <AccountSection email={email} onUpdateEmail={setEmail} />
-        <NotificationSection preferences={notifications} onToggle={handleToggleNotification} />
-        <AppPreferencesSection preferences={appPreferences} onUpdate={handleUpdatePreference} />
+        <AccountSection />
+        {/* TODO: Future feature — email notification pipeline
+            <NotificationSection preferences={notifications} onToggle={handleToggleNotification} />
+        */}
+        <AppPreferencesSection preferences={preferences} onUpdate={updatePreference} />
       </div>
 
       <div className="mt-8 pt-6 border-t border-zinc-800">

--- a/src/app/api/auth/change-email/route.ts
+++ b/src/app/api/auth/change-email/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod/v4";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { createClient } from "@/lib/supabase-server";
+import { validateBody } from "@/lib/validate-body";
+
+export async function POST(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { email } = await validateBody(request, z.object({ email: z.email() }));
+
+      const supabase = await createClient();
+      const { error } = await supabase.auth.updateUser({ email });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      logger.info("Email change requested", { userId: user.id });
+      return NextResponse.json({ message: "Confirmation email sent" }, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,31 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { z } from "zod/v4";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { createClient } from "@/lib/supabase-server";
+import { validateBody } from "@/lib/validate-body";
+
+export async function POST(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { email } = await validateBody(request, z.object({ email: z.email() }));
+
+      const supabase = await createClient();
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/reset-password`,
+      });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      logger.info("Password reset requested", { userId: user.id });
+      return NextResponse.json({ message: "Reset email sent" }, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { getSettings, upsertSettings } from "@/services/settings";
+import { UserPreferencesSchema } from "@/types/schemas";
+
+export async function GET(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const preferences = await getSettings(user.id);
+      return NextResponse.json(preferences, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}
+
+export async function PATCH(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const patch = await validateBody(request, UserPreferencesSchema);
+      const preferences = await upsertSettings(user.id, patch);
+      logger.info("Settings updated", { userId: user.id });
+      return NextResponse.json(preferences, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -1,30 +1,71 @@
 "use client";
 
-import { useState } from "react";
-
-type AccountSectionProps = {
-  email: string;
-  onUpdateEmail: (email: string) => void;
-};
+import { useEffect, useState } from "react";
+import { showToast } from "@/components/ui/toast";
 
 const inputStyles =
   "w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent";
 
 const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
 
-export function AccountSection({ email, onUpdateEmail }: AccountSectionProps) {
+export function AccountSection() {
+  const [email, setEmail] = useState("");
   const [editingEmail, setEditingEmail] = useState(false);
-  const [newEmail, setNewEmail] = useState(email);
+  const [newEmail, setNewEmail] = useState("");
+  const [saving, setSaving] = useState(false);
 
-  function handleSaveEmail() {
-    if (newEmail.trim()) {
-      onUpdateEmail(newEmail.trim());
+  useEffect(() => {
+    fetch("/api/profile")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.email) setEmail(data.email);
+      })
+      .catch(() => {});
+  }, []);
+
+  async function handleSaveEmail() {
+    if (!newEmail.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/auth/change-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: newEmail.trim() }),
+      });
+      if (res.ok) {
+        showToast("Confirmation email sent to new address");
+        setEditingEmail(false);
+      } else {
+        const data = await res.json();
+        showToast(data.error || "Failed to change email", "error");
+      }
+    } catch {
+      showToast("Failed to change email", "error");
+    } finally {
+      setSaving(false);
     }
-    setEditingEmail(false);
+  }
+
+  async function handleResetPassword() {
+    try {
+      const res = await fetch("/api/auth/reset-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (res.ok) {
+        showToast("Password reset email sent");
+      } else {
+        const data = await res.json();
+        showToast(data.error || "Failed to send reset email", "error");
+      }
+    } catch {
+      showToast("Failed to send reset email", "error");
+    }
   }
 
   function handleCancelEmail() {
-    setNewEmail(email);
+    setNewEmail("");
     setEditingEmail(false);
   }
 
@@ -32,14 +73,16 @@ export function AccountSection({ email, onUpdateEmail }: AccountSectionProps) {
     <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
       <h2 className="text-lg font-semibold text-zinc-50 mb-6">Account</h2>
 
-      {/* Email */}
       <div className="mb-6 pb-6 border-b border-zinc-800">
         <div className="flex items-center justify-between mb-2">
           <p className="text-sm font-medium text-zinc-300">Email Address</p>
           {!editingEmail && (
             <button
               type="button"
-              onClick={() => setEditingEmail(true)}
+              onClick={() => {
+                setNewEmail(email);
+                setEditingEmail(true);
+              }}
               className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-3 py-1.5 rounded-md text-xs font-medium"
             >
               Change
@@ -73,9 +116,10 @@ export function AccountSection({ email, onUpdateEmail }: AccountSectionProps) {
               <button
                 type="button"
                 onClick={handleSaveEmail}
-                className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
+                disabled={saving}
+                className="bg-indigo-500 hover:bg-indigo-600 disabled:opacity-50 text-zinc-50 px-4 py-2 rounded-md text-sm font-medium"
               >
-                Save
+                {saving ? "Saving..." : "Save"}
               </button>
             </div>
           </div>
@@ -86,10 +130,18 @@ export function AccountSection({ email, onUpdateEmail }: AccountSectionProps) {
         )}
       </div>
 
-      {/* Password — coming soon */}
-      <div>
-        <p className="text-sm font-medium text-zinc-300">Password</p>
-        <p className="mt-1 text-sm text-zinc-500">Password change will be available soon.</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-zinc-300">Password</p>
+          <p className="mt-1 text-xs text-zinc-500">Send a password reset link to your email.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleResetPassword}
+          className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 px-3 py-1.5 rounded-md text-xs font-medium"
+        >
+          Reset Password
+        </button>
       </div>
     </div>
   );

--- a/src/components/settings/app-preferences-section.tsx
+++ b/src/components/settings/app-preferences-section.tsx
@@ -1,18 +1,62 @@
 "use client";
 
 import { Select } from "@/components/ui/select";
+import type { DashboardView, UserPreferences } from "@/types/settings";
 
 type AppPreferencesSectionProps = {
-  preferences: {
-    defaultJobStage: string;
-    showArchived: boolean;
-  };
-  onUpdate: (key: string, value: string | boolean) => void;
+  preferences: UserPreferences;
+  onUpdate: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => void;
 };
 
 const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
 
-const JOB_STAGES = ["Interested", "Applied", "Interview", "Offer"];
+const JOB_STAGES = [
+  { value: "INTERESTED", label: "Interested" },
+  { value: "APPLIED", label: "Applied" },
+  { value: "INTERVIEW", label: "Interview" },
+  { value: "OFFER", label: "Offer" },
+] as const;
+
+const DASHBOARD_VIEWS = [
+  { value: "card", label: "Card" },
+  { value: "list", label: "List" },
+] as const;
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-center justify-between py-3">
+      <div>
+        <p className="text-sm font-medium text-zinc-300">{label}</p>
+        <p className="text-xs text-zinc-500">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={onChange}
+        className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent cursor-pointer transition-colors ${
+          checked ? "bg-indigo-500" : "bg-zinc-700"
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-zinc-50 shadow-sm transition-transform ${
+            checked ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}
 
 export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesSectionProps) {
   return (
@@ -27,32 +71,60 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
           <Select
             id="defaultStage"
             value={preferences.defaultJobStage}
-            onChange={(val) => onUpdate("defaultJobStage", val)}
-            options={JOB_STAGES.map((stage) => ({ value: stage, label: stage }))}
+            onChange={(val) =>
+              onUpdate("defaultJobStage", val as UserPreferences["defaultJobStage"])
+            }
+            options={[...JOB_STAGES]}
           />
         </div>
 
-        <div className="flex items-center justify-between py-3">
-          <div>
-            <p className="text-sm font-medium text-zinc-300">Show archived jobs</p>
-            <p className="text-xs text-zinc-500">Display archived jobs on the dashboard.</p>
-          </div>
-          <button
-            type="button"
-            role="switch"
-            aria-checked={preferences.showArchived}
-            onClick={() => onUpdate("showArchived", !preferences.showArchived)}
-            className={`relative inline-flex h-6 w-11 shrink-0 rounded-full border-2 border-transparent cursor-pointer transition-colors ${
-              preferences.showArchived ? "bg-indigo-500" : "bg-zinc-700"
-            }`}
-          >
-            <span
-              className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-zinc-50 shadow-sm transition-transform ${
-                preferences.showArchived ? "translate-x-5" : "translate-x-0"
-              }`}
-            />
-          </button>
+        <div>
+          <label className={labelStyles} htmlFor="dashboardView">
+            Dashboard view
+          </label>
+          <Select
+            id="dashboardView"
+            value={preferences.dashboardView}
+            onChange={(val) => onUpdate("dashboardView", val as DashboardView)}
+            options={[...DASHBOARD_VIEWS]}
+          />
         </div>
+
+        <Toggle
+          checked={preferences.showArchived}
+          onChange={() => onUpdate("showArchived", !preferences.showArchived)}
+          label="Show archived jobs"
+          description="Display archived jobs on the dashboard."
+        />
+
+        <Toggle
+          checked={preferences.autoArchiveRejected}
+          onChange={() => onUpdate("autoArchiveRejected", !preferences.autoArchiveRejected)}
+          label="Auto-archive rejected jobs"
+          description="Automatically archive jobs after they've been rejected."
+        />
+
+        {preferences.autoArchiveRejected && (
+          <div>
+            <label className={labelStyles} htmlFor="archiveDays">
+              Days before auto-archiving
+            </label>
+            <input
+              id="archiveDays"
+              type="number"
+              min={1}
+              max={365}
+              value={preferences.autoArchiveRejectedDays}
+              onChange={(e) => {
+                const val = Number.parseInt(e.target.value, 10);
+                if (val >= 1 && val <= 365) {
+                  onUpdate("autoArchiveRejectedDays", val);
+                }
+              }}
+              className="w-24 bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+            />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/services/settings.ts
+++ b/src/services/settings.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/services/prisma";
+import type { UserPreferences } from "@/types/settings";
+import { DEFAULT_PREFERENCES } from "@/types/settings";
+
+function mergeWithDefaults(partial: Record<string, unknown> | null): UserPreferences {
+  if (!partial) return { ...DEFAULT_PREFERENCES };
+  return { ...DEFAULT_PREFERENCES, ...partial };
+}
+
+export async function getSettings(userId: string): Promise<UserPreferences> {
+  const row = await prisma.userSettings.findUnique({
+    where: { userId },
+    select: { preferences: true },
+  });
+  return mergeWithDefaults(row?.preferences as Record<string, unknown> | null);
+}
+
+export async function upsertSettings(
+  userId: string,
+  patch: Partial<UserPreferences>
+): Promise<UserPreferences> {
+  const current = await getSettings(userId);
+  const merged = { ...current, ...patch };
+
+  await prisma.userSettings.upsert({
+    where: { userId },
+    create: { userId, preferences: merged },
+    update: { preferences: merged },
+  });
+
+  return merged;
+}

--- a/src/tests/api/settings.test.ts
+++ b/src/tests/api/settings.test.ts
@@ -1,0 +1,104 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSettings, mockUpsertSettings, mockRequireAuth } = vi.hoisted(() => ({
+  mockGetSettings: vi.fn(),
+  mockUpsertSettings: vi.fn(),
+  mockRequireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+  logError: vi.fn(),
+}));
+
+vi.mock("@/services/settings", () => ({
+  getSettings: mockGetSettings,
+  upsertSettings: mockUpsertSettings,
+}));
+
+import { GET, PATCH } from "@/app/api/settings/route";
+
+const mockUser = { id: "user-123" };
+const defaultPrefs = {
+  defaultJobStage: "INTERESTED",
+  showArchived: false,
+  dashboardView: "card" as const,
+  autoArchiveRejected: false,
+  autoArchiveRejectedDays: 30,
+};
+
+describe("GET /api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+    const req = new Request("http://localhost/api/settings") as NextRequest;
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns user preferences", async () => {
+    mockGetSettings.mockResolvedValue(defaultPrefs);
+    const req = new Request("http://localhost/api/settings") as NextRequest;
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual(defaultPrefs);
+  });
+});
+
+describe("PATCH /api/settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+    const req = new Request("http://localhost/api/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ showArchived: true }),
+    }) as NextRequest;
+    const res = await PATCH(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("updates and returns merged preferences", async () => {
+    const updated = { ...defaultPrefs, showArchived: true };
+    mockUpsertSettings.mockResolvedValue(updated);
+    const req = new Request("http://localhost/api/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ showArchived: true }),
+    }) as NextRequest;
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.showArchived).toBe(true);
+  });
+
+  it("returns 400 for invalid input", async () => {
+    const req = new Request("http://localhost/api/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ autoArchiveRejectedDays: 999 }),
+    }) as NextRequest;
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/tests/services/settings.test.ts
+++ b/src/tests/services/settings.test.ts
@@ -44,7 +44,7 @@ describe("settings service", () => {
         preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
       });
 
-      const result = await upsertSettings("user-1", { showArchived: true });
+      await upsertSettings("user-1", { showArchived: true });
 
       expect(mockUpsert).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/tests/services/settings.test.ts
+++ b/src/tests/services/settings.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFindUnique = vi.fn();
+const mockUpsert = vi.fn();
+
+vi.mock("@/services/prisma", () => ({
+  prisma: {
+    userSettings: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+    },
+  },
+}));
+
+const { getSettings, upsertSettings } = await import("@/services/settings");
+const { DEFAULT_PREFERENCES } = await import("@/types/settings");
+
+describe("settings service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getSettings", () => {
+    it("returns defaults when no settings row exists", async () => {
+      mockFindUnique.mockResolvedValue(null);
+      const result = await getSettings("user-1");
+      expect(result).toEqual(DEFAULT_PREFERENCES);
+    });
+
+    it("merges stored preferences with defaults", async () => {
+      mockFindUnique.mockResolvedValue({
+        preferences: { showArchived: true },
+      });
+      const result = await getSettings("user-1");
+      expect(result.showArchived).toBe(true);
+      expect(result.defaultJobStage).toBe(DEFAULT_PREFERENCES.defaultJobStage);
+    });
+  });
+
+  describe("upsertSettings", () => {
+    it("creates settings row with partial update merged into defaults", async () => {
+      mockFindUnique.mockResolvedValue(null);
+      mockUpsert.mockResolvedValue({
+        preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+      });
+
+      const result = await upsertSettings("user-1", { showArchived: true });
+
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { userId: "user-1" },
+          create: expect.objectContaining({
+            userId: "user-1",
+            preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+          }),
+          update: expect.objectContaining({
+            preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+          }),
+        })
+      );
+    });
+
+    it("merges partial update with existing preferences", async () => {
+      mockFindUnique.mockResolvedValue({
+        preferences: { ...DEFAULT_PREFERENCES, defaultJobStage: "APPLIED" },
+      });
+      mockUpsert.mockResolvedValue({
+        preferences: {
+          ...DEFAULT_PREFERENCES,
+          defaultJobStage: "APPLIED",
+          showArchived: true,
+        },
+      });
+
+      await upsertSettings("user-1", { showArchived: true });
+
+      expect(mockUpsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          update: expect.objectContaining({
+            preferences: expect.objectContaining({
+              defaultJobStage: "APPLIED",
+              showArchived: true,
+            }),
+          }),
+        })
+      );
+    });
+  });
+});

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -9,3 +9,4 @@ export {
 } from "./document";
 export { CreateJobSchema, JobStageSchema, UpdateJobSchema } from "./job";
 export { ProfilePatchSchema } from "./profile";
+export { UserPreferencesSchema } from "./settings";

--- a/src/types/schemas/settings.ts
+++ b/src/types/schemas/settings.ts
@@ -1,0 +1,13 @@
+import { z } from "zod/v4";
+
+export const DEFAULT_JOB_STAGES = ["INTERESTED", "APPLIED", "INTERVIEW", "OFFER"] as const;
+
+export const UserPreferencesSchema = z.object({
+  defaultJobStage: z.enum(DEFAULT_JOB_STAGES).optional(),
+  showArchived: z.boolean().optional(),
+  dashboardView: z.enum(["card", "list"]).optional(),
+  autoArchiveRejected: z.boolean().optional(),
+  autoArchiveRejectedDays: z.number().int().min(1).max(365).optional(),
+});
+
+export type UserPreferencesInput = z.infer<typeof UserPreferencesSchema>;

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,17 @@
+export type DashboardView = "card" | "list";
+
+export type UserPreferences = {
+  defaultJobStage: "INTERESTED" | "APPLIED" | "INTERVIEW" | "OFFER";
+  showArchived: boolean;
+  dashboardView: DashboardView;
+  autoArchiveRejected: boolean;
+  autoArchiveRejectedDays: number;
+};
+
+export const DEFAULT_PREFERENCES: UserPreferences = {
+  defaultJobStage: "INTERESTED",
+  showArchived: false,
+  dashboardView: "card",
+  autoArchiveRejected: false,
+  autoArchiveRejectedDays: 30,
+};


### PR DESCRIPTION
## Summary
- Add `UserSettings` Prisma model with JSON `preferences` column for extensible, server-persisted settings
- Wire settings page to `/api/settings` (GET/PATCH) with typed `UserPreferences` and Zod validation
- Connect account section to Supabase Auth (email change via `updateUser`, password reset via `resetPasswordForEmail`)
- Add two new settings: `dashboardView` (card/list) and `autoArchiveRejected` (toggle + days)
- Comment out notification section (future feature — no email pipeline yet)
- 9 new tests (4 service, 5 API), all 137 tests passing, type-check/lint/build clean