### PR TITLE
feat(dashboard): card/list view toggle + UI polish

### DIFF
--- a/src/app/(app)/dashboard/[jobId]/followups-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/followups-section.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
 import type { JobActivity } from "@/types/activity";
 
@@ -20,9 +22,7 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
   const emptyForm = { title: "", scheduledAt: "", description: "" };
   const [form, setForm] = useState(emptyForm);
 
-  function handleChange(
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   }
 
@@ -43,7 +43,10 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
   }
 
   async function handleSave() {
-    if (!form.title.trim()) { showToast("Follow-up title is required", "error"); return; }
+    if (!form.title.trim()) {
+      showToast("Follow-up title is required", "error");
+      return;
+    }
     setSaving(true);
     try {
       const payload = {
@@ -123,8 +126,11 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-medium text-zinc-50">Follow-ups</h2>
         {!showForm && (
-          <button type="button" onClick={() => setShowForm(true)}
-            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors">
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
             + Add follow-up
           </button>
         )}
@@ -135,29 +141,46 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
           <h3 className="text-sm font-medium text-zinc-200">
             {editingId ? "Edit follow-up" : "Add follow-up"}
           </h3>
-          <div>
-            <label htmlFor="fu-title" className="block text-xs font-medium text-zinc-400 mb-1">Task *</label>
-            <input id="fu-title" name="title" type="text" value={form.title} onChange={handleChange}
-              placeholder="e.g. Send thank-you email to recruiter"
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-          </div>
-          <div>
-            <label htmlFor="fu-due" className="block text-xs font-medium text-zinc-400 mb-1">Due date</label>
-            <input id="fu-due" name="scheduledAt" type="datetime-local" value={form.scheduledAt}
-              onChange={handleChange}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-          </div>
-          <div>
-            <label htmlFor="fu-notes" className="block text-xs font-medium text-zinc-400 mb-1">Notes</label>
-            <textarea id="fu-notes" name="description" value={form.description} onChange={handleChange}
-              placeholder="Optional notes..." rows={2}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y" />
-          </div>
+          <Input
+            id="fu-title"
+            label="Task *"
+            name="title"
+            type="text"
+            value={form.title}
+            onChange={handleChange}
+            placeholder="e.g. Send thank-you email to recruiter"
+          />
+          <Input
+            id="fu-due"
+            label="Due date"
+            name="scheduledAt"
+            type="datetime-local"
+            value={form.scheduledAt}
+            onChange={handleChange}
+          />
+          <Textarea
+            id="fu-notes"
+            label="Notes"
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            placeholder="Optional notes..."
+            rows={2}
+          />
           <div className="flex justify-end gap-2">
-            <button type="button" onClick={handleCancel}
-              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm">Cancel</button>
-            <button type="button" onClick={handleSave} disabled={saving}
-              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50"
+            >
               {saving ? "Saving..." : editingId ? "Save changes" : "Add follow-up"}
             </button>
           </div>
@@ -173,11 +196,16 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
           {incomplete.length > 0 && (
             <div className="space-y-2">
               {incomplete.map((activity) => (
-                <FollowUpRow key={activity.id} activity={activity} overdue={isOverdue(activity)}
-                  toggling={toggling === activity.id} deleting={deleting === activity.id}
+                <FollowUpRow
+                  key={activity.id}
+                  activity={activity}
+                  overdue={isOverdue(activity)}
+                  toggling={toggling === activity.id}
+                  deleting={deleting === activity.id}
                   onToggle={() => handleToggleComplete(activity)}
                   onEdit={() => startEdit(activity)}
-                  onDelete={() => handleDelete(activity.id)} />
+                  onDelete={() => handleDelete(activity.id)}
+                />
               ))}
             </div>
           )}
@@ -186,11 +214,16 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
               <p className="text-xs font-medium text-zinc-500 mb-2 mt-4">Completed</p>
               <div className="space-y-2 opacity-60">
                 {completed.map((activity) => (
-                  <FollowUpRow key={activity.id} activity={activity} overdue={false}
-                    toggling={toggling === activity.id} deleting={deleting === activity.id}
+                  <FollowUpRow
+                    key={activity.id}
+                    activity={activity}
+                    overdue={false}
+                    toggling={toggling === activity.id}
+                    deleting={deleting === activity.id}
                     onToggle={() => handleToggleComplete(activity)}
                     onEdit={() => startEdit(activity)}
-                    onDelete={() => handleDelete(activity.id)} />
+                    onDelete={() => handleDelete(activity.id)}
+                  />
                 ))}
               </div>
             </div>
@@ -201,34 +234,67 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
   );
 }
 
-function FollowUpRow({ activity, overdue, toggling, deleting, onToggle, onEdit, onDelete }: {
-  activity: JobActivity; overdue: boolean; toggling: boolean; deleting: boolean;
-  onToggle: () => void; onEdit: () => void; onDelete: () => void;
+function FollowUpRow({
+  activity,
+  overdue,
+  toggling,
+  deleting,
+  onToggle,
+  onEdit,
+  onDelete,
+}: {
+  activity: JobActivity;
+  overdue: boolean;
+  toggling: boolean;
+  deleting: boolean;
+  onToggle: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
 }) {
   return (
-    <div className={`flex items-start gap-3 bg-zinc-800 border rounded-lg px-4 py-3 ${overdue ? "border-red-900/60" : "border-zinc-700"}`}>
-      <button type="button" onClick={onToggle} disabled={toggling}
+    <div
+      className={`flex items-start gap-3 bg-zinc-800 border rounded-lg px-4 py-3 ${overdue ? "border-red-900/60" : "border-zinc-700"}`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={toggling}
         aria-label={activity.completed ? "Mark incomplete" : "Mark complete"}
         className={`mt-0.5 w-4 h-4 shrink-0 rounded border flex items-center justify-center transition-colors ${
-          activity.completed ? "bg-indigo-500 border-indigo-500" : "border-zinc-500 hover:border-indigo-400"
-        } disabled:opacity-50`}>
+          activity.completed
+            ? "bg-indigo-500 border-indigo-500"
+            : "border-zinc-500 hover:border-indigo-400"
+        } disabled:opacity-50`}
+      >
         {activity.completed && (
-          <svg width="10" height="10" viewBox="0 0 12 12" fill="none"
-  stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
-  aria-hidden="true">
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="white"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
             <polyline points="2 6 5 9 10 3" />
           </svg>
         )}
       </button>
       <div className="flex-1 min-w-0">
-        <p className={`text-sm font-medium ${activity.completed ? "line-through text-zinc-500" : "text-zinc-200"}`}>
+        <p
+          className={`text-sm font-medium ${activity.completed ? "line-through text-zinc-500" : "text-zinc-200"}`}
+        >
           {activity.title}
         </p>
         {activity.scheduledAt && (
           <p className={`text-xs mt-0.5 ${overdue ? "text-red-400" : "text-zinc-400"}`}>
             {overdue ? "Overdue · " : "Due "}
             {new Date(activity.scheduledAt).toLocaleDateString("en-US", {
-              month: "short", day: "numeric", year: "numeric",
+              month: "short",
+              day: "numeric",
+              year: "numeric",
             })}
           </p>
         )}
@@ -237,10 +303,19 @@ function FollowUpRow({ activity, overdue, toggling, deleting, onToggle, onEdit, 
         )}
       </div>
       <div className="flex items-center gap-1 shrink-0">
-        <button type="button" onClick={onEdit}
-          className="text-xs text-zinc-400 hover:text-zinc-50 px-2 py-1 rounded hover:bg-zinc-700 transition-colors">Edit</button>
-        <button type="button" onClick={onDelete} disabled={deleting}
-          className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-zinc-700 transition-colors disabled:opacity-50">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="text-xs text-zinc-400 hover:text-zinc-50 px-2 py-1 rounded hover:bg-zinc-700 transition-colors"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          disabled={deleting}
+          className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-zinc-700 transition-colors disabled:opacity-50"
+        >
           {deleting ? "..." : "Delete"}
         </button>
       </div>

--- a/src/app/(app)/dashboard/[jobId]/interviews-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/interviews-section.tsx
@@ -1,12 +1,20 @@
 "use client";
 
 import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
 import type { JobActivity } from "@/types/activity";
 
 const ROUND_TYPES = [
-  "Phone Screen", "Technical Screen", "Hiring Manager",
-  "Panel", "Take-Home", "On-Site", "Final Round", "Other",
+  "Phone Screen",
+  "Technical Screen",
+  "Hiring Manager",
+  "Panel",
+  "Take-Home",
+  "On-Site",
+  "Final Round",
+  "Other",
 ];
 
 interface Props {
@@ -48,7 +56,10 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
   }
 
   async function handleSave() {
-    if (!form.title.trim()) { showToast("Interview title is required", "error"); return; }
+    if (!form.title.trim()) {
+      showToast("Interview title is required", "error");
+      return;
+    }
     setSaving(true);
     try {
       const payload = {
@@ -102,8 +113,11 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-medium text-zinc-50">Interviews</h2>
         {!showForm && (
-          <button type="button" onClick={() => setShowForm(true)}
-            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors">
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
             + Add interview
           </button>
         )}
@@ -116,37 +130,65 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
           </h3>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label htmlFor="roundType" className="block text-xs font-medium text-zinc-400 mb-1">Round type</label>
-              <select id="roundType" name="roundType" value={form.roundType} onChange={handleChange}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <label htmlFor="roundType" className="block text-xs font-medium text-zinc-400 mb-1">
+                Round type
+              </label>
+              <select
+                id="roundType"
+                name="roundType"
+                value={form.roundType}
+                onChange={handleChange}
+                className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              >
                 <option value="">Select round type</option>
-                {ROUND_TYPES.map((r) => <option key={r} value={r}>{r}</option>)}
+                {ROUND_TYPES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
               </select>
             </div>
-            <div>
-              <label htmlFor="scheduledAt" className="block text-xs font-medium text-zinc-400 mb-1">Date &amp; time</label>
-              <input id="scheduledAt" name="scheduledAt" type="datetime-local" value={form.scheduledAt}
-                onChange={handleChange}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-            </div>
+            <Input
+              id="scheduledAt"
+              label="Date & time"
+              name="scheduledAt"
+              type="datetime-local"
+              value={form.scheduledAt}
+              onChange={handleChange}
+            />
           </div>
-          <div>
-            <label htmlFor="int-title" className="block text-xs font-medium text-zinc-400 mb-1">Title *</label>
-            <input id="int-title" name="title" type="text" value={form.title} onChange={handleChange}
-              placeholder="e.g. Technical screen with eng team"
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-          </div>
-          <div>
-            <label htmlFor="int-notes" className="block text-xs font-medium text-zinc-400 mb-1">Notes</label>
-            <textarea id="int-notes" name="description" value={form.description} onChange={handleChange}
-              placeholder="Interviewer names, topics covered, how it went..." rows={3}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y" />
-          </div>
+          <Input
+            id="int-title"
+            label="Title *"
+            name="title"
+            type="text"
+            value={form.title}
+            onChange={handleChange}
+            placeholder="e.g. Technical screen with eng team"
+          />
+          <Textarea
+            id="int-notes"
+            label="Notes"
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            placeholder="Interviewer names, topics covered, how it went..."
+            rows={3}
+          />
           <div className="flex justify-end gap-2">
-            <button type="button" onClick={handleCancel}
-              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm">Cancel</button>
-            <button type="button" onClick={handleSave} disabled={saving}
-              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50">
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50"
+            >
               {saving ? "Saving..." : editingId ? "Save changes" : "Add interview"}
             </button>
           </div>
@@ -158,7 +200,10 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
       ) : (
         <div className="space-y-3">
           {sorted.map((activity) => (
-            <div key={activity.id} className="bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3">
+            <div
+              key={activity.id}
+              className="bg-zinc-800 border border-zinc-700 rounded-lg px-4 py-3"
+            >
               <div className="flex items-start justify-between gap-2">
                 <div>
                   {activity.roundType && (
@@ -170,20 +215,34 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
                   {activity.scheduledAt && (
                     <p className="text-xs text-zinc-400 mt-0.5">
                       {new Date(activity.scheduledAt).toLocaleString("en-US", {
-                        month: "short", day: "numeric", year: "numeric",
-                        hour: "numeric", minute: "2-digit",
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
                       })}
                     </p>
                   )}
                   {activity.description && (
-                    <p className="text-xs text-zinc-400 mt-1 whitespace-pre-wrap">{activity.description}</p>
+                    <p className="text-xs text-zinc-400 mt-1 whitespace-pre-wrap">
+                      {activity.description}
+                    </p>
                   )}
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
-                  <button type="button" onClick={() => startEdit(activity)}
-                    className="text-xs text-zinc-400 hover:text-zinc-50 px-2 py-1 rounded hover:bg-zinc-700 transition-colors">Edit</button>
-                  <button type="button" onClick={() => handleDelete(activity.id)} disabled={deleting === activity.id}
-                    className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-zinc-700 transition-colors disabled:opacity-50">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(activity)}
+                    className="text-xs text-zinc-400 hover:text-zinc-50 px-2 py-1 rounded hover:bg-zinc-700 transition-colors"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(activity.id)}
+                    disabled={deleting === activity.id}
+                    className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-zinc-700 transition-colors disabled:opacity-50"
+                  >
                     {deleting === activity.id ? "..." : "Delete"}
                   </button>
                 </div>

--- a/src/app/(app)/dashboard/[jobId]/overview-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/overview-section.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
+import { STAGES } from "@/constants/job-stages";
 import type { Job, JobStage } from "@/types/job";
 
 interface Props {
   job: Job;
   onJobUpdated: (job: Job) => void;
 }
-
-const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
 
 export function OverviewSection({ job, onJobUpdated }: Props) {
   const [editing, setEditing] = useState(false);
@@ -27,9 +29,7 @@ export function OverviewSection({ job, onJobUpdated }: Props) {
     stage: job.stage,
   });
 
-  function handleChange(
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
   }
 
@@ -53,8 +53,14 @@ export function OverviewSection({ job, onJobUpdated }: Props) {
   }
 
   async function handleSave() {
-    if (!form.title.trim()) { showToast("Job title is required", "error"); return; }
-    if (!form.company.trim()) { showToast("Company is required", "error"); return; }
+    if (!form.title.trim()) {
+      showToast("Job title is required", "error");
+      return;
+    }
+    if (!form.company.trim()) {
+      showToast("Company is required", "error");
+      return;
+    }
 
     setSaving(true);
     try {
@@ -73,7 +79,10 @@ export function OverviewSection({ job, onJobUpdated }: Props) {
           stage: form.stage,
         }),
       });
-      if (!res.ok) { showToast("Failed to save changes", "error"); return; }
+      if (!res.ok) {
+        showToast("Failed to save changes", "error");
+        return;
+      }
       const updated: Job = await res.json();
       onJobUpdated(updated);
       setEditing(false);
@@ -90,18 +99,29 @@ export function OverviewSection({ job, onJobUpdated }: Props) {
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-medium text-zinc-50">Overview</h2>
         {!editing ? (
-          <button type="button" onClick={() => setEditing(true)}
-            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
             Edit
           </button>
         ) : (
           <div className="flex items-center gap-2">
-            <button type="button" onClick={handleCancel} disabled={saving}
-              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-md text-sm disabled:opacity-50 transition-colors">
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={saving}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-300 px-3 py-1.5 rounded-md text-sm disabled:opacity-50 transition-colors"
+            >
               Cancel
             </button>
-            <button type="button" onClick={handleSave} disabled={saving}
-              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 transition-colors">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50 transition-colors"
+            >
               {saving ? "Saving..." : "Save"}
             </button>
           </div>
@@ -109,91 +129,192 @@ export function OverviewSection({ job, onJobUpdated }: Props) {
       </div>
 
       <div className="space-y-5">
-        <div className="grid grid-cols-3 gap-4">
-          <Field label="Job title *" id="title" name="title" value={form.title}
-            editing={editing} onChange={handleChange} />
-          <Field label="Company *" id="company" name="company" value={form.company}
-            editing={editing} onChange={handleChange} />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <Field
+            label="Job title *"
+            id="title"
+            name="title"
+            value={form.title}
+            editing={editing}
+            onChange={handleChange}
+          />
+          <Field
+            label="Company *"
+            id="company"
+            name="company"
+            value={form.company}
+            editing={editing}
+            onChange={handleChange}
+          />
           <div>
-            <label htmlFor="stage" className="block text-xs font-medium text-zinc-400 mb-1">Stage</label>
+            <label htmlFor="stage" className="block text-xs font-medium text-zinc-400 mb-1">
+              Stage
+            </label>
             {editing ? (
-              <select id="stage" value={form.stage} onChange={(e) => handleStageChange(e.target.value as JobStage)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent">
-                {STAGES.map((s) => (
-                  <option key={s} value={s}>{s}</option>
-                ))}
-              </select>
+              <Select
+                id="stage"
+                value={form.stage}
+                onChange={(val) => handleStageChange(val as JobStage)}
+                options={STAGES.map((s) => ({ value: s, label: s }))}
+              />
             ) : (
               <p className="text-sm text-zinc-300 py-2 min-h-[36px]">{form.stage}</p>
             )}
           </div>
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="Location" id="location" name="location" value={form.location}
-            editing={editing} onChange={handleChange} placeholder="City, State or Remote" />
-          <Field label="Application date" id="applicationDate" name="applicationDate"
-            value={form.applicationDate} editing={editing} onChange={handleChange} type="date" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Field
+            label="Location"
+            id="location"
+            name="location"
+            value={form.location}
+            editing={editing}
+            onChange={handleChange}
+            placeholder="City, State or Remote"
+          />
+          <Field
+            label="Application date"
+            id="applicationDate"
+            name="applicationDate"
+            value={form.applicationDate}
+            editing={editing}
+            onChange={handleChange}
+            type="date"
+          />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="Deadline" id="deadline" name="deadline" value={form.deadline}
-            editing={editing} onChange={handleChange} type="date" />
-          <Field label="Compensation notes" id="compensationNotes" name="compensationNotes"
-            value={form.compensationNotes} editing={editing} onChange={handleChange}
-            placeholder="e.g. $120k + equity" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Field
+            label="Deadline"
+            id="deadline"
+            name="deadline"
+            value={form.deadline}
+            editing={editing}
+            onChange={handleChange}
+            type="date"
+          />
+          <Field
+            label="Compensation notes"
+            id="compensationNotes"
+            name="compensationNotes"
+            value={form.compensationNotes}
+            editing={editing}
+            onChange={handleChange}
+            placeholder="e.g. $120k + equity"
+          />
         </div>
 
-        <TextareaField label="Job description" id="description" name="description"
-          value={form.description} editing={editing} onChange={handleChange}
-          placeholder="Paste the job description here..." rows={6} />
+        <TextareaField
+          label="Job description"
+          id="description"
+          name="description"
+          value={form.description}
+          editing={editing}
+          onChange={handleChange}
+          placeholder="Paste the job description here..."
+          rows={6}
+        />
 
-        <TextareaField label="Recruiter / contact notes" id="recruiterNotes" name="recruiterNotes"
-          value={form.recruiterNotes} editing={editing} onChange={handleChange}
-          placeholder="Recruiter name, email, phone, LinkedIn..." rows={3} />
+        <TextareaField
+          label="Recruiter / contact notes"
+          id="recruiterNotes"
+          name="recruiterNotes"
+          value={form.recruiterNotes}
+          editing={editing}
+          onChange={handleChange}
+          placeholder="Recruiter name, email, phone, LinkedIn..."
+          rows={3}
+        />
       </div>
     </div>
   );
 }
 
-function Field({ label, id, name, value, editing, onChange, type = "text", placeholder = "" }: {
-  label: string; id: string; name: string; value: string;
-  editing: boolean; onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  type?: string; placeholder?: string;
+function Field({
+  label,
+  id,
+  name,
+  value,
+  editing,
+  onChange,
+  type = "text",
+  placeholder = "",
+}: {
+  label: string;
+  id: string;
+  name: string;
+  value: string;
+  editing: boolean;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  type?: string;
+  placeholder?: string;
 }) {
-  return (
-    <div>
-      <label htmlFor={id} className="block text-xs font-medium text-zinc-400 mb-1">{label}</label>
-      {editing ? (
-        <input id={id} name={name} type={type} value={value} onChange={onChange}
-          placeholder={placeholder}
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent" />
-      ) : (
+  if (!editing) {
+    return (
+      <div>
+        <label htmlFor={id} className="block text-xs font-medium text-zinc-400 mb-1">
+          {label}
+        </label>
         <p className="text-sm text-zinc-300 py-2 min-h-[36px]">
           {value || <span className="text-zinc-600 italic">Not set</span>}
         </p>
-      )}
-    </div>
+      </div>
+    );
+  }
+  return (
+    <Input
+      id={id}
+      label={label}
+      name={name}
+      type={type}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+    />
   );
 }
 
-function TextareaField({ label, id, name, value, editing, onChange, placeholder = "", rows = 4 }: {
-  label: string; id: string; name: string; value: string;
-  editing: boolean; onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  placeholder?: string; rows?: number;
+function TextareaField({
+  label,
+  id,
+  name,
+  value,
+  editing,
+  onChange,
+  placeholder = "",
+  rows = 4,
+}: {
+  label: string;
+  id: string;
+  name: string;
+  value: string;
+  editing: boolean;
+  onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  placeholder?: string;
+  rows?: number;
 }) {
-  return (
-    <div>
-      <label htmlFor={id} className="block text-xs font-medium text-zinc-400 mb-1">{label}</label>
-      {editing ? (
-        <textarea id={id} name={name} value={value} onChange={onChange}
-          placeholder={placeholder} rows={rows}
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent resize-y" />
-      ) : (
+  if (!editing) {
+    return (
+      <div>
+        <label htmlFor={id} className="block text-xs font-medium text-zinc-400 mb-1">
+          {label}
+        </label>
         <p className="text-sm text-zinc-300 whitespace-pre-wrap min-h-[36px] py-1">
           {value || <span className="text-zinc-600 italic">Not set</span>}
         </p>
-      )}
-    </div>
+      </div>
+    );
+  }
+  return (
+    <Textarea
+      id={id}
+      label={label}
+      name={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      rows={rows}
+    />
   );
 }

--- a/src/app/(app)/dashboard/[jobId]/page.tsx
+++ b/src/app/(app)/dashboard/[jobId]/page.tsx
@@ -2,30 +2,26 @@
 
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
+import { showToast } from "@/components/ui/toast";
+import type { JobActivity } from "@/types/activity";
+import type { Job } from "@/types/job";
+import { FollowUpsSection } from "./followups-section";
+import { InterviewsSection } from "./interviews-section";
 import { OverviewSection } from "./overview-section";
 import { TimelineSection } from "./timeline-section";
-import { InterviewsSection } from "./interviews-section";
-import { FollowUpsSection } from "./followups-section";
-import { showToast } from "@/components/ui/toast";
-import type { Job } from "@/types/job";
-import type { JobActivity } from "@/types/activity";
 
 type Tab = "overview" | "timeline" | "interviews" | "followups";
 
 const STAGE_STYLES: Record<string, string> = {
-  Interested: "bg-zinc-800 text-zinc-300",
-  Applied:    "bg-blue-950 text-blue-400",
-  Interview:  "bg-amber-950 text-amber-400",
-  Offer:      "bg-green-950 text-green-400",
-  Rejected:   "bg-red-950 text-red-400",
-  Archived:   "bg-zinc-900 text-zinc-500",
+  Interested: "bg-zinc-800 text-zinc-400",
+  Applied: "bg-blue-950 text-blue-400",
+  Interview: "bg-yellow-950 text-yellow-400",
+  Offer: "bg-green-950 text-green-400",
+  Rejected: "bg-red-950 text-red-400",
+  Archived: "bg-zinc-900 text-zinc-500",
 };
 
-export default function JobDetailPage({
-  params,
-}: {
-  params: Promise<{ jobId: string }>;
-}) {
+export default function JobDetailPage({ params }: { params: Promise<{ jobId: string }> }) {
   const router = useRouter();
   const [jobId, setJobId] = useState<string | null>(null);
   const [job, setJob] = useState<Job | null>(null);
@@ -41,8 +37,14 @@ export default function JobDetailPage({
     if (!jobId) return;
     try {
       const res = await fetch(`/api/jobs/${jobId}`);
-      if (res.status === 401) { router.push("/login"); return; }
-      if (res.status === 404) { router.push("/dashboard"); return; }
+      if (res.status === 401) {
+        router.push("/login");
+        return;
+      }
+      if (res.status === 404) {
+        router.push("/dashboard");
+        return;
+      }
       if (!res.ok) throw new Error();
       setJob(await res.json());
     } catch {
@@ -69,7 +71,7 @@ export default function JobDetailPage({
 
   if (loading) {
     return (
-      <div className="animate-pulse space-y-4">
+      <div className="animate-pulse space-y-4" role="status" aria-label="Loading job details">
         <div className="h-4 w-24 bg-zinc-800 rounded" />
         <div className="h-8 w-64 bg-zinc-800 rounded" />
         <div className="h-4 w-40 bg-zinc-800 rounded" />
@@ -88,11 +90,22 @@ export default function JobDetailPage({
 
   return (
     <div>
-      <button type="button" onClick={() => router.push("/dashboard")}
-        className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-50 mb-6 transition-colors">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
-          stroke="currentColor" strokeWidth="2" strokeLinecap="round"
-          strokeLinejoin="round" aria-hidden="true">
+      <button
+        type="button"
+        onClick={() => router.push("/dashboard")}
+        className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-zinc-50 mb-6 transition-colors"
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
           <polyline points="15 18 9 12 15 6" />
         </svg>
         Back to dashboard
@@ -103,33 +116,81 @@ export default function JobDetailPage({
           <div>
             <h1 className="text-2xl font-semibold text-zinc-50">{job.title}</h1>
             <p className="mt-1 text-sm text-zinc-400">
-              {job.company}{job.location ? ` · ${job.location}` : ""}
+              {job.company}
+              {job.location ? ` · ${job.location}` : ""}
             </p>
           </div>
-          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STAGE_STYLES[job.stage] ?? "bg-zinc-800 text-zinc-300"}`}>
+          <span
+            className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STAGE_STYLES[job.stage] ?? "bg-zinc-800 text-zinc-300"}`}
+          >
             {job.stage}
           </span>
         </div>
       </div>
 
-      <div className="flex gap-1 border-b border-zinc-800 mb-6">
+      <div
+        role="tablist"
+        aria-label="Job sections"
+        className="flex gap-1 border-b border-zinc-800 mb-6"
+      >
         {TABS.map((tab) => (
-          <button key={tab.id} type="button" onClick={() => setActiveTab(tab.id)}
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            id={`tab-${tab.id}`}
+            onClick={() => setActiveTab(tab.id)}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
               activeTab === tab.id
                 ? "border-indigo-500 text-indigo-400"
                 : "border-transparent text-zinc-400 hover:text-zinc-50"
-            }`}>
+            }`}
+          >
             {tab.label}
           </button>
         ))}
       </div>
 
       {activeTab === "overview" && (
-        <OverviewSection job={job} onJobUpdated={(updated) => setJob(updated)} />
+        <div role="tabpanel" id="panel-overview" aria-labelledby="tab-overview">
+          <OverviewSection job={job} onJobUpdated={(updated) => setJob(updated)} />
+        </div>
       )}
       {activeTab === "timeline" && (
-        <TimelineSection activities={activities} jobId={job.id} onActivitiesChanged={fetchActivities} />
+        <div role="tabpanel" id="panel-timeline" aria-labelledby="tab-timeline">
+          <TimelineSection
+            activities={activities}
+            jobId={job.id}
+            onActivitiesChanged={fetchActivities}
+          />
+        </div>
+      )}
+      {activeTab === "interviews" && (
+        <div role="tabpanel" id="panel-interviews" aria-labelledby="tab-interviews">
+          <InterviewsSection
+            activities={activities.filter((a) => a.type === "INTERVIEW")}
+            jobId={job.id}
+            onActivitiesChanged={fetchActivities}
+          />
+        </div>
+      )}
+      {activeTab === "followups" && (
+        <div role="tabpanel" id="panel-followups" aria-labelledby="tab-followups">
+          <FollowUpsSection
+            activities={activities.filter((a) => a.type === "FOLLOWUP")}
+            jobId={job.id}
+            onActivitiesChanged={fetchActivities}
+          />
+        </div>
+      )}
+      {activeTab === "timeline" && (
+        <TimelineSection
+          activities={activities}
+          jobId={job.id}
+          onActivitiesChanged={fetchActivities}
+        />
       )}
       {activeTab === "interviews" && (
         <InterviewsSection

--- a/src/app/(app)/dashboard/[jobId]/timeline-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/timeline-section.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
 import type { JobActivity } from "@/types/activity";
 
@@ -21,7 +23,10 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
   );
 
   async function handleAddNote() {
-    if (!noteTitle.trim()) { showToast("Note title is required", "error"); return; }
+    if (!noteTitle.trim()) {
+      showToast("Note title is required", "error");
+      return;
+    }
     setSaving(true);
     try {
       const res = await fetch(`/api/jobs/${jobId}/activities`, {
@@ -50,35 +55,51 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
     <div className="bg-zinc-900 border border-zinc-700 rounded-lg p-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-medium text-zinc-50">Timeline</h2>
-        <button type="button" onClick={() => setAddingNote(true)}
-          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors">
+        <button
+          type="button"
+          onClick={() => setAddingNote(true)}
+          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+        >
           + Add note
         </button>
       </div>
 
       {addingNote && (
         <div className="mb-6 bg-zinc-800 border border-zinc-700 rounded-lg p-4 space-y-3">
-          <div>
-            <label htmlFor="note-title" className="block text-xs font-medium text-zinc-400 mb-1">Note title *</label>
-            <input id="note-title" type="text" value={noteTitle}
-              onChange={(e) => setNoteTitle(e.target.value)}
-              placeholder="e.g. Heard back from recruiter"
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
-          </div>
-          <div>
-            <label htmlFor="note-desc" className="block text-xs font-medium text-zinc-400 mb-1">Details</label>
-            <textarea id="note-desc" value={noteDesc} onChange={(e) => setNoteDesc(e.target.value)}
-              placeholder="Optional details..." rows={3}
-              className="w-full bg-zinc-900 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y" />
-          </div>
+          <Input
+            id="note-title"
+            label="Note title *"
+            type="text"
+            value={noteTitle}
+            onChange={(e) => setNoteTitle(e.target.value)}
+            placeholder="e.g. Heard back from recruiter"
+          />
+          <Textarea
+            id="note-desc"
+            label="Details"
+            value={noteDesc}
+            onChange={(e) => setNoteDesc(e.target.value)}
+            placeholder="Optional details..."
+            rows={3}
+          />
           <div className="flex justify-end gap-2">
-            <button type="button"
-              onClick={() => { setAddingNote(false); setNoteTitle(""); setNoteDesc(""); }}
-              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm">
+            <button
+              type="button"
+              onClick={() => {
+                setAddingNote(false);
+                setNoteTitle("");
+                setNoteDesc("");
+              }}
+              className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm"
+            >
               Cancel
             </button>
-            <button type="button" onClick={handleAddNote} disabled={saving}
-              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50">
+            <button
+              type="button"
+              onClick={handleAddNote}
+              disabled={saving}
+              className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50"
+            >
               {saving ? "Saving..." : "Add note"}
             </button>
           </div>
@@ -94,7 +115,9 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
           {sorted.map((activity) => (
             <li key={activity.id} className="ml-6">
               <span className="absolute -left-[9px] flex items-center justify-center w-4 h-4 rounded-full bg-zinc-800 border border-zinc-600 mt-1">
-                <span className={`w-1.5 h-1.5 rounded-full ${DOT_COLORS[activity.type] ?? "bg-zinc-500"}`} />
+                <span
+                  className={`w-1.5 h-1.5 rounded-full ${DOT_COLORS[activity.type] ?? "bg-zinc-500"}`}
+                />
               </span>
               <div>
                 <p className="text-sm font-medium text-zinc-200">{activity.title}</p>
@@ -102,12 +125,16 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
                   <p className="text-xs text-zinc-400 mt-0.5">{activity.description}</p>
                 )}
                 <div className="flex items-center gap-2 mt-1">
-                  <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TYPE_BADGE[activity.type] ?? "bg-zinc-800 text-zinc-400"}`}>
+                  <span
+                    className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TYPE_BADGE[activity.type] ?? "bg-zinc-800 text-zinc-400"}`}
+                  >
                     {activity.type.charAt(0) + activity.type.slice(1).toLowerCase()}
                   </span>
                   <span className="text-xs text-zinc-500">
                     {new Date(activity.createdAt).toLocaleDateString("en-US", {
-                      month: "short", day: "numeric", year: "numeric",
+                      month: "short",
+                      day: "numeric",
+                      year: "numeric",
                     })}
                   </span>
                 </div>
@@ -121,12 +148,19 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
 }
 
 const DOT_COLORS: Record<string, string> = {
-  STAGE: "bg-indigo-500", APPLIED: "bg-blue-500", INTERVIEW: "bg-amber-500",
-  FOLLOWUP: "bg-zinc-400", NOTE: "bg-zinc-500", OUTCOME: "bg-green-500",
+  STAGE: "bg-indigo-500",
+  APPLIED: "bg-blue-500",
+  INTERVIEW: "bg-amber-500",
+  FOLLOWUP: "bg-zinc-400",
+  NOTE: "bg-zinc-500",
+  OUTCOME: "bg-green-500",
 };
 
 const TYPE_BADGE: Record<string, string> = {
-  STAGE: "bg-indigo-950 text-indigo-400", APPLIED: "bg-blue-950 text-blue-400",
-  INTERVIEW: "bg-amber-950 text-amber-400", FOLLOWUP: "bg-zinc-800 text-zinc-300",
-  NOTE: "bg-zinc-800 text-zinc-400", OUTCOME: "bg-green-950 text-green-400",
+  STAGE: "bg-indigo-950 text-indigo-400",
+  APPLIED: "bg-blue-950 text-blue-400",
+  INTERVIEW: "bg-amber-950 text-amber-400",
+  FOLLOWUP: "bg-zinc-800 text-zinc-300",
+  NOTE: "bg-zinc-800 text-zinc-400",
+  OUTCOME: "bg-green-950 text-green-400",
 };

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -4,11 +4,12 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import AddJobModal from "@/components/dashboard/add-job-modal";
 import FilterBar from "@/components/dashboard/filter-bar";
-import JobCardList from "@/components/dashboard/job-card-list";
+import JobList from "@/components/dashboard/job-list";
 import { MetricsPanel } from "@/components/dashboard/metrics-panel";
 import { ConfirmDeleteModal } from "@/components/ui/confirm-delete-modal";
 import { DashboardSkeleton } from "@/components/ui/skeletons/dashboard-skeleton";
 import { showToast } from "@/components/ui/toast";
+import { useViewMode } from "@/hooks/use-view-mode";
 import type { Job, JobStage } from "@/types/job";
 
 export default function DashboardPage() {
@@ -20,6 +21,7 @@ export default function DashboardPage() {
   const [filtered, setFiltered] = useState<Job[]>([]);
   const [pendingDeleteJob, setPendingDeleteJob] = useState<Job | null>(null);
   const onFilteredChange = useCallback((f: Job[]) => setFiltered(f), []);
+  const [viewMode, setViewMode] = useViewMode();
 
   useEffect(() => {
     fetch("/api/jobs")
@@ -194,14 +196,20 @@ export default function DashboardPage() {
       <MetricsPanel />
 
       {/* Filter bar */}
-      <FilterBar jobs={jobs} onFilteredChange={onFilteredChange} />
+      <FilterBar
+        jobs={jobs}
+        onFilteredChange={onFilteredChange}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+      />
 
       {/* Job board */}
       {loading ? (
         <DashboardSkeleton />
       ) : (
-        <JobCardList
+        <JobList
           jobs={filtered}
+          viewMode={viewMode}
           onEdit={handleEditClick}
           onDelete={(id) => {
             const job = jobs.find((j) => j.id === id);

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -18,7 +18,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
     <div className="flex min-h-screen">
       <Sidebar firstName={profile?.firstName} lastName={profile?.lastName} />
       <main className="flex-1 overflow-y-auto">
-        <div className="max-w-5xl mx-auto px-8 pt-8 pb-16">{children}</div>
+        <div className="max-w-5xl mx-auto px-4 sm:px-8 pt-8 pb-16">{children}</div>
       </main>
       <ToastContainer />
     </div>

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { LogoutButton } from "@/components/dashboard/logout-button";
 import { AccountSection } from "@/components/settings/account-section";
 import { AppPreferencesSection } from "@/components/settings/app-preferences-section";
+import { SettingsSkeleton } from "@/components/ui/skeletons/settings-skeleton";
 import { showToast } from "@/components/ui/toast";
 import type { UserPreferences } from "@/types/settings";
 import { DEFAULT_PREFERENCES } from "@/types/settings";
@@ -41,17 +42,7 @@ export default function SettingsPage() {
   );
 
   if (loading) {
-    return (
-      <>
-        <div className="mb-8">
-          <h1 className="text-2xl font-semibold text-zinc-50">Settings</h1>
-          <p className="mt-1 text-sm text-zinc-400">
-            Manage your account, notifications, and preferences.
-          </p>
-        </div>
-        <div className="text-sm text-zinc-500">Loading...</div>
-      </>
-    );
+    return <SettingsSkeleton />;
   }
 
   return (

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type SyntheticEvent, useState } from "react";
+import { Input } from "@/components/ui/input";
 import { createClient } from "@/services/supabase";
 import type { ForgotPasswordFormData } from "@/types";
 
@@ -60,18 +61,7 @@ export function ForgotPasswordForm() {
         </div>
       )}
 
-      <div>
-        <label htmlFor="email" className="mb-1 block text-xs font-medium text-zinc-400">
-          Email
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="text"
-          placeholder="you@example.com"
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
+      <Input id="email" label="Email" name="email" type="text" placeholder="you@example.com" />
 
       <button
         type="submit"

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { type SyntheticEvent, useState } from "react";
+import { Input } from "@/components/ui/input";
 import type { LoginFormData } from "@/types";
 
 export function LoginForm() {
@@ -50,33 +51,22 @@ export function LoginForm() {
         </div>
       )}
 
-      <div>
-        <label htmlFor="email" className="mb-1 block text-xs font-medium text-zinc-400">
-          Email
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          required
-          placeholder="you@example.com"
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="password" className="mb-1 block text-xs font-medium text-zinc-400">
-          Password
-        </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          required
-          placeholder="••••••••"
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
+      <Input
+        id="email"
+        label="Email"
+        name="email"
+        type="email"
+        required
+        placeholder="you@example.com"
+      />
+      <Input
+        id="password"
+        label="Password"
+        name="password"
+        type="password"
+        required
+        placeholder="••••••••"
+      />
 
       <button
         type="submit"

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { type SyntheticEvent, useState } from "react";
+import { Input } from "@/components/ui/input";
 import type { RegisterFormData } from "@/types";
 
 export function RegisterForm() {
@@ -95,47 +96,30 @@ export function RegisterForm() {
         </div>
       )}
 
-      <div>
-        <label htmlFor="email" className="mb-1 block text-xs font-medium text-zinc-400">
-          Email
-        </label>
-        <input
-          id="email"
-          name="email"
-          type="email"
-          placeholder="you@example.com"
-          required
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="password" className="mb-1 block text-xs font-medium text-zinc-400">
-          Password
-        </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          placeholder="••••••••"
-          required
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="confirmPassword" className="mb-1 block text-xs font-medium text-zinc-400">
-          Confirm Password
-        </label>
-        <input
-          id="confirmPassword"
-          name="confirmPassword"
-          type="password"
-          placeholder="••••••••"
-          required
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
+      <Input
+        id="email"
+        label="Email"
+        name="email"
+        type="email"
+        required
+        placeholder="you@example.com"
+      />
+      <Input
+        id="password"
+        label="Password"
+        name="password"
+        type="password"
+        required
+        placeholder="••••••••"
+      />
+      <Input
+        id="confirmPassword"
+        label="Confirm Password"
+        name="confirmPassword"
+        type="password"
+        required
+        placeholder="••••••••"
+      />
 
       <button
         type="submit"

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type SyntheticEvent, useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
 import { createClient } from "@/services/supabase";
 import type { ResetPasswordFormData } from "@/types";
 
@@ -116,31 +117,20 @@ export function ResetPasswordForm() {
         </div>
       )}
 
-      <div>
-        <label htmlFor="password" className="mb-1 block text-xs font-medium text-zinc-400">
-          New Password
-        </label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          placeholder="••••••••"
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="confirmPassword" className="mb-1 block text-xs font-medium text-zinc-400">
-          Confirm New Password
-        </label>
-        <input
-          id="confirmPassword"
-          name="confirmPassword"
-          type="password"
-          placeholder="••••••••"
-          className="w-full bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
-        />
-      </div>
+      <Input
+        id="password"
+        label="New Password"
+        name="password"
+        type="password"
+        placeholder="••••••••"
+      />
+      <Input
+        id="confirmPassword"
+        label="Confirm New Password"
+        name="confirmPassword"
+        type="password"
+        placeholder="••••••••"
+      />
 
       <button
         type="submit"

--- a/src/components/dashboard/filter-bar.tsx
+++ b/src/components/dashboard/filter-bar.tsx
@@ -123,6 +123,7 @@ export default function FilterBar({
             placeholder="Search jobs..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search jobs"
             className="w-full bg-zinc-800 border border-zinc-700 rounded-md pl-9 pr-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
           />
         </div>

--- a/src/components/dashboard/filter-bar.tsx
+++ b/src/components/dashboard/filter-bar.tsx
@@ -3,19 +3,25 @@
 import { useEffect, useMemo, useState } from "react";
 import { Select } from "@/components/ui/select";
 import { DEADLINE_STATE_OPTIONS, getDeadlineState } from "@/constants/job-filters";
-import type { Job, JobStage } from "@/types/job";
+import { STAGES } from "@/constants/job-stages";
+import type { Job, JobStage, ViewMode } from "@/types/job";
 import { searchJobs } from "@/utils/search-jobs";
 import type { SortKey } from "@/utils/sort-jobs";
 import { sortJobs } from "@/utils/sort-jobs";
 
-const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
-
 type FilterBarProps = {
   jobs: Job[];
   onFilteredChange: (filtered: Job[]) => void;
+  viewMode: ViewMode;
+  onViewModeChange: (mode: ViewMode) => void;
 };
 
-export default function FilterBar({ jobs, onFilteredChange }: FilterBarProps) {
+export default function FilterBar({
+  jobs,
+  onFilteredChange,
+  viewMode,
+  onViewModeChange,
+}: FilterBarProps) {
   const [search, setSearch] = useState("");
   const [stageFilter, setStageFilter] = useState<JobStage | "">("");
   const [locationFilter, setLocationFilter] = useState("");
@@ -94,9 +100,9 @@ export default function FilterBar({ jobs, onFilteredChange }: FilterBarProps) {
 
   return (
     <div className="mb-6">
-      {/* Toolbar: Search, Filters, Sort */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-        <div className="relative flex-1">
+      {/* Row 1: Search */}
+      <div className="mb-3">
+        <div className="relative">
           <svg
             className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500"
             width="16"
@@ -120,7 +126,10 @@ export default function FilterBar({ jobs, onFilteredChange }: FilterBarProps) {
             className="w-full bg-zinc-800 border border-zinc-700 rounded-md pl-9 pr-3 py-2 text-sm text-zinc-50 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
           />
         </div>
+      </div>
 
+      {/* Row 2: Filters + Sort + View toggle */}
+      <div className="flex flex-wrap items-center gap-2">
         <Select
           value={stageFilter}
           onChange={(val) => setStageFilter(val as JobStage | "")}
@@ -157,6 +166,70 @@ export default function FilterBar({ jobs, onFilteredChange }: FilterBarProps) {
           ]}
           className="sm:w-36"
         />
+
+        {/* Spacer pushes toggle right */}
+        <div className="flex-1" />
+
+        {/* View toggle */}
+        {/* biome-ignore lint/a11y/useSemanticElements: visual toggle in flex toolbar, fieldset breaks layout */}
+        <div
+          className="flex rounded-md border border-zinc-700 overflow-hidden"
+          role="group"
+          aria-label="View mode"
+        >
+          <button
+            type="button"
+            aria-pressed={viewMode === "card"}
+            aria-label="Card view"
+            onClick={() => onViewModeChange("card")}
+            className={`p-1.5 ${viewMode === "card" ? "bg-zinc-700 text-zinc-50" : "bg-zinc-800 text-zinc-500 hover:text-zinc-300"}`}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <title>Card view</title>
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            aria-pressed={viewMode === "list"}
+            aria-label="List view"
+            onClick={() => onViewModeChange("list")}
+            className={`p-1.5 ${viewMode === "list" ? "bg-zinc-700 text-zinc-50" : "bg-zinc-800 text-zinc-500 hover:text-zinc-300"}`}
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <title>List view</title>
+              <line x1="8" y1="6" x2="21" y2="6" />
+              <line x1="8" y1="12" x2="21" y2="12" />
+              <line x1="8" y1="18" x2="21" y2="18" />
+              <line x1="3" y1="6" x2="3.01" y2="6" />
+              <line x1="3" y1="12" x2="3.01" y2="12" />
+              <line x1="3" y1="18" x2="3.01" y2="18" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {/* Active filter chips */}

--- a/src/components/dashboard/job-card.tsx
+++ b/src/components/dashboard/job-card.tsx
@@ -75,7 +75,7 @@ export default function JobCard({ job, onEdit, onDelete, onStageChange }: JobCar
             value={job.stage}
             onChange={handleStageChange}
             options={STAGES.map((s) => ({ value: s, label: s }))}
-            className="text-xs font-medium"
+            className="w-[110px] text-xs font-medium"
             textClassName={STAGE_TEXT_STYLES[job.stage]}
           />
         </div>

--- a/src/components/dashboard/job-card.tsx
+++ b/src/components/dashboard/job-card.tsx
@@ -38,7 +38,7 @@ export default function JobCard({ job, onEdit, onDelete, onStageChange }: JobCar
       <div className="flex items-start justify-between gap-3">
         <button
           type="button"
-          className="flex-1 text-left"
+          className="flex-1 min-w-0 text-left"
           onClick={() => router.push(`/dashboard/${job.id}`)}
           aria-label={`View details for ${job.title} at ${job.company}`}
         >

--- a/src/components/dashboard/job-card.tsx
+++ b/src/components/dashboard/job-card.tsx
@@ -7,28 +7,15 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Select } from "@/components/ui/select";
+import { STAGE_TEXT_STYLES, STAGES } from "@/constants/job-stages";
 import type { Job, JobStage } from "@/types/job";
+import { isOverdue } from "@/utils/deadline";
 
 type JobCardProps = {
   job: Job;
   onEdit?: (job: Job) => void;
   onDelete?: (id: string) => void;
   onStageChange?: (id: string, stage: JobStage) => void;
-};
-
-const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected", "Archived"];
-
-function isOverdue(deadline: string): boolean {
-  return deadline < new Date().toISOString().slice(0, 10);
-}
-
-const STAGE_TEXT_STYLES: Record<JobStage, string> = {
-  Interested: "text-zinc-400",
-  Applied: "text-blue-400",
-  Interview: "text-yellow-400",
-  Offer: "text-green-400",
-  Rejected: "text-red-400",
-  Archived: "text-zinc-500",
 };
 
 export default function JobCard({ job, onEdit, onDelete, onStageChange }: JobCardProps) {

--- a/src/components/dashboard/job-list-item.tsx
+++ b/src/components/dashboard/job-list-item.tsx
@@ -69,19 +69,17 @@ export default function JobListItem({ job, onEdit, onDelete, onStageChange }: Jo
           />
         </div>
 
-        {job.deadline && (
-          <span
-            className={`shrink-0 text-xs ${isOverdue(job.deadline) ? "text-red-400" : "text-zinc-500"}`}
-          >
-            {job.deadline}
-          </span>
-        )}
+        <span
+          className={`shrink-0 w-20 text-xs text-right ${job.deadline ? (isOverdue(job.deadline) ? "text-red-400" : "text-zinc-500") : "invisible"}`}
+        >
+          {job.deadline}
+        </span>
 
-        {job.priority && (
-          <span className="shrink-0 bg-yellow-950 text-yellow-400 rounded px-1.5 py-0.5 text-xs font-medium">
+        <span className={`shrink-0 w-16 text-center ${job.priority ? "" : "invisible"}`}>
+          <span className="bg-yellow-950 text-yellow-400 rounded px-1.5 py-0.5 text-xs font-medium">
             Priority
           </span>
-        )}
+        </span>
 
         <div className="shrink-0 flex gap-1.5">
           {onEdit && (

--- a/src/components/dashboard/job-list-item.tsx
+++ b/src/components/dashboard/job-list-item.tsx
@@ -64,7 +64,7 @@ export default function JobListItem({ job, onEdit, onDelete, onStageChange }: Jo
             value={job.stage}
             onChange={handleStageChange}
             options={STAGES.map((s) => ({ value: s, label: s }))}
-            className="text-xs font-medium"
+            className="w-[110px] text-xs font-medium"
             textClassName={STAGE_TEXT_STYLES[job.stage]}
           />
         </div>

--- a/src/components/dashboard/job-list-item.tsx
+++ b/src/components/dashboard/job-list-item.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Select } from "@/components/ui/select";
+import { STAGE_TEXT_STYLES, STAGES } from "@/constants/job-stages";
+import type { Job, JobStage } from "@/types/job";
+import { isOverdue } from "@/utils/deadline";
+
+type JobListItemProps = {
+  job: Job;
+  onEdit?: (job: Job) => void;
+  onDelete?: (id: string) => void;
+  onStageChange?: (id: string, stage: JobStage) => void;
+};
+
+export default function JobListItem({ job, onEdit, onDelete, onStageChange }: JobListItemProps) {
+  const router = useRouter();
+  const [isChangingStage, setIsChangingStage] = useState(false);
+
+  async function handleStageChange(val: string) {
+    const newStage = val as JobStage;
+    if (newStage === job.stage || !onStageChange) return;
+    setIsChangingStage(true);
+    try {
+      await onStageChange(job.id, newStage);
+    } finally {
+      setIsChangingStage(false);
+    }
+  }
+
+  return (
+    <div className="bg-zinc-900 border border-zinc-700 hover:border-zinc-500 rounded-lg px-4 py-3 transition-colors">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="flex-1 min-w-0 text-left"
+          onClick={() => router.push(`/dashboard/${job.id}`)}
+          aria-label={`View details for ${job.title} at ${job.company}`}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-sm font-medium text-zinc-50 truncate">{job.title}</span>
+            <span className="text-sm text-zinc-500 shrink-0">at</span>
+            <span className="text-sm text-zinc-400 truncate">{job.company}</span>
+          </div>
+        </button>
+
+        <div className="shrink-0 flex items-center gap-1.5">
+          {isChangingStage && (
+            <svg
+              className="animate-spin text-zinc-500"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              aria-hidden="true"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          )}
+          <Select
+            value={job.stage}
+            onChange={handleStageChange}
+            options={STAGES.map((s) => ({ value: s, label: s }))}
+            className="text-xs font-medium"
+            textClassName={STAGE_TEXT_STYLES[job.stage]}
+          />
+        </div>
+
+        {job.deadline && (
+          <span
+            className={`shrink-0 text-xs ${isOverdue(job.deadline) ? "text-red-400" : "text-zinc-500"}`}
+          >
+            {job.deadline}
+          </span>
+        )}
+
+        {job.priority && (
+          <span className="shrink-0 bg-yellow-950 text-yellow-400 rounded px-1.5 py-0.5 text-xs font-medium">
+            Priority
+          </span>
+        )}
+
+        <div className="shrink-0 flex gap-1.5">
+          {onEdit && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit(job);
+              }}
+              className="bg-zinc-800 border border-zinc-700 hover:bg-zinc-700 text-zinc-50 rounded-md px-2 py-1 text-xs font-medium"
+              aria-label={`Edit ${job.title}`}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+              </svg>
+            </button>
+          )}
+
+          {onDelete && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDelete(job.id);
+              }}
+              className="bg-red-600 hover:bg-red-700 text-zinc-50 rounded-md px-2 py-1 text-xs font-medium"
+              aria-label={`Delete ${job.title}`}
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/job-list.tsx
+++ b/src/components/dashboard/job-list.tsx
@@ -1,14 +1,16 @@
 import JobCard from "@/components/dashboard/job-card";
-import type { Job, JobStage } from "@/types/job";
+import JobListItem from "@/components/dashboard/job-list-item";
+import type { Job, JobStage, ViewMode } from "@/types/job";
 
-type JobCardListProps = {
+type JobListProps = {
   jobs: Job[];
+  viewMode: ViewMode;
   onEdit?: (job: Job) => void;
   onDelete?: (id: string) => void;
   onStageChange?: (id: string, stage: JobStage) => void;
 };
 
-export default function JobCardList({ jobs, onEdit, onDelete, onStageChange }: JobCardListProps) {
+export default function JobList({ jobs, viewMode, onEdit, onDelete, onStageChange }: JobListProps) {
   if (!jobs || jobs.length === 0) {
     return (
       <div className="bg-zinc-900 border border-dashed border-zinc-700 rounded-lg p-10 text-center">
@@ -31,6 +33,22 @@ export default function JobCardList({ jobs, onEdit, onDelete, onStageChange }: J
         <p className="mt-1 text-xs text-zinc-500">
           Click &quot;Add Job&quot; to start tracking your applications.
         </p>
+      </div>
+    );
+  }
+
+  if (viewMode === "list") {
+    return (
+      <div className="flex flex-col gap-2">
+        {jobs.map((job) => (
+          <JobListItem
+            key={job.id}
+            job={job}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onStageChange={onStageChange}
+          />
+        ))}
       </div>
     );
   }

--- a/src/components/profile/experience-section.tsx
+++ b/src/components/profile/experience-section.tsx
@@ -217,6 +217,13 @@ export function ExperienceSection({ experiences, onUpdate }: ExperienceSectionPr
                 );
               })}
             </ul>
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="w-full border border-dashed border-zinc-700 rounded-lg py-3 text-sm text-indigo-400 hover:text-indigo-300 hover:border-zinc-600 transition-colors"
+            >
+              + Add experience
+            </button>
           </div>
         )}
       </div>

--- a/src/components/profile/experience-section.tsx
+++ b/src/components/profile/experience-section.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { type DragEvent, useState } from "react";
+import { ExperienceForm } from "@/components/profile/experience-form";
+import { ConfirmDeleteModal } from "@/components/ui/confirm-delete-modal";
+import { Modal } from "@/components/ui/modal";
 import type { Experience } from "@/types/profile";
 
 type ExperienceSectionProps = {
@@ -23,7 +26,7 @@ function formatDateRange(exp: Experience): string {
 }
 
 export function ExperienceSection({ experiences, onUpdate }: ExperienceSectionProps) {
-  const [_modalOpen, setModalOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [deleteIndex, setDeleteIndex] = useState<number | null>(null);
   const [draggedIndex, setDraggedIndex] = useState<number | null>(null);
@@ -48,7 +51,7 @@ export function ExperienceSection({ experiences, onUpdate }: ExperienceSectionPr
     setEditingIndex(null);
   }
 
-  function _confirmDelete() {
+  function confirmDelete() {
     if (deleteIndex === null) return;
 
     onUpdate(
@@ -59,7 +62,7 @@ export function ExperienceSection({ experiences, onUpdate }: ExperienceSectionPr
     setDeleteIndex(null);
   }
 
-  function _handleSave(experience: Experience) {
+  function handleSave(experience: Experience) {
     if (editingIndex !== null) {
       const updated = experiences.map((exp, i) => (i === editingIndex ? experience : exp));
       onUpdate(updated, "Experience updated");
@@ -100,116 +103,147 @@ export function ExperienceSection({ experiences, onUpdate }: ExperienceSectionPr
     setDragOverIndex(null);
   }
 
-  const _deleteItem = deleteIndex !== null ? experiences[deleteIndex] : null;
+  const deleteItem = deleteIndex !== null ? experiences[deleteIndex] : null;
 
   return (
-    <div className="rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-sm">
-      <h2 className="mb-4 text-lg font-semibold text-zinc-50">Experience</h2>
+    <>
+      <div className="rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-zinc-50">Experience</h2>
 
-      {experiences.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-zinc-700 py-8">
-          <p className="text-sm text-zinc-500">No experience added yet</p>
-          <button
-            type="button"
-            onClick={handleAdd}
-            className="text-sm text-indigo-400 hover:text-indigo-300"
-          >
-            + Add your first experience
-          </button>
-        </div>
-      ) : (
-        <div>
-          <ul className="space-y-3">
-            {experiences.map((exp, index) => {
-              const isDragging = draggedIndex === index;
-              const isDragTarget = dragOverIndex === index && draggedIndex !== index;
+        {experiences.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-zinc-700 py-8">
+            <p className="text-sm text-zinc-500">No experience added yet</p>
+            <button
+              type="button"
+              onClick={handleAdd}
+              className="text-sm text-indigo-400 hover:text-indigo-300"
+            >
+              + Add your first experience
+            </button>
+          </div>
+        ) : (
+          <div>
+            <ul className="space-y-3">
+              {experiences.map((exp, index) => {
+                const isDragging = draggedIndex === index;
+                const isDragTarget = dragOverIndex === index && draggedIndex !== index;
 
-              return (
-                <li
-                  key={exp.id || index}
-                  draggable
-                  onDragStart={() => handleDragStart(index)}
-                  onDragOver={(e) => handleDragOver(e, index)}
-                  onDrop={() => handleDrop(index)}
-                  onDragEnd={handleDragEnd}
-                  className={[
-                    "group list-none rounded-lg border bg-zinc-950/40 p-4 transition-colors",
-                    isDragging
-                      ? "border-indigo-500 opacity-50"
-                      : isDragTarget
-                        ? "border-indigo-400"
-                        : "border-zinc-700 hover:border-zinc-600",
-                  ].join(" ")}
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <button
-                      type="button"
-                      onClick={() => handleEdit(index)}
-                      className="min-w-0 flex-1 text-left"
-                    >
-                      <p className="text-sm font-medium text-zinc-50">
-                        {exp.title || <span className="text-zinc-600">Untitled</span>}
-                        {exp.organization && (
-                          <span className="font-normal text-zinc-400"> at {exp.organization}</span>
-                        )}
-                      </p>
-
-                      <p className="mt-0.5 text-xs text-zinc-500">{formatDateRange(exp)}</p>
-
-                      {exp.description && (
-                        <p className="mt-2 line-clamp-2 text-sm text-zinc-400">{exp.description}</p>
-                      )}
-                    </button>
-
-                    <div className="flex shrink-0 items-center gap-1">
-                      <span
-                        className="select-none px-2 py-1 text-zinc-500 cursor-grab active:cursor-grabbing"
-                        title="Drag to reorder"
-                        aria-hidden="true"
-                      >
-                        ⋮⋮
-                      </span>
-
+                return (
+                  <li
+                    key={exp.id || index}
+                    draggable
+                    onDragStart={() => handleDragStart(index)}
+                    onDragOver={(e) => handleDragOver(e, index)}
+                    onDrop={() => handleDrop(index)}
+                    onDragEnd={handleDragEnd}
+                    className={[
+                      "group list-none rounded-lg border bg-zinc-950/40 p-4 transition-colors",
+                      isDragging
+                        ? "border-indigo-500 opacity-50"
+                        : isDragTarget
+                          ? "border-indigo-400"
+                          : "border-zinc-700 hover:border-zinc-600",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-start justify-between gap-3">
                       <button
                         type="button"
                         onClick={() => handleEdit(index)}
-                        className="p-1.5 text-zinc-500 transition-colors hover:text-indigo-400"
-                        aria-label="Edit"
-                        title="Edit"
+                        className="min-w-0 flex-1 text-left"
                       >
-                        ✎
+                        <p className="text-sm font-medium text-zinc-50">
+                          {exp.title || <span className="text-zinc-600">Untitled</span>}
+                          {exp.organization && (
+                            <span className="font-normal text-zinc-400">
+                              {" "}
+                              at {exp.organization}
+                            </span>
+                          )}
+                        </p>
+
+                        <p className="mt-0.5 text-xs text-zinc-500">{formatDateRange(exp)}</p>
+
+                        {exp.description && (
+                          <p className="mt-2 line-clamp-2 text-sm text-zinc-400">
+                            {exp.description}
+                          </p>
+                        )}
                       </button>
 
-                      <button
-                        type="button"
-                        onClick={() => handleDelete(index)}
-                        className="p-1.5 text-zinc-500 transition-colors hover:text-red-400"
-                        aria-label="Delete"
-                        title="Delete"
-                      >
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
+                      <div className="flex shrink-0 items-center gap-1">
+                        <span
+                          className="select-none px-2 py-1 text-zinc-500 cursor-grab active:cursor-grabbing"
+                          title="Drag to reorder"
                           aria-hidden="true"
                         >
-                          <polyline points="3 6 5 6 21 6" />
-                          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-                        </svg>
-                      </button>
+                          ⋮⋮
+                        </span>
+
+                        <button
+                          type="button"
+                          onClick={() => handleEdit(index)}
+                          className="p-1.5 text-zinc-500 transition-colors hover:text-indigo-400"
+                          aria-label="Edit"
+                          title="Edit"
+                        >
+                          ✎
+                        </button>
+
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(index)}
+                          className="p-1.5 text-zinc-500 transition-colors hover:text-red-400"
+                          aria-label="Delete"
+                          title="Delete"
+                        >
+                          <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden="true"
+                          >
+                            <polyline points="3 6 5 6 21 6" />
+                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                          </svg>
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )}
-    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      <Modal
+        open={modalOpen}
+        onClose={handleCloseModal}
+        title={editingIndex !== null ? "Edit experience" : "Add experience"}
+        maxWidth="lg"
+      >
+        <ExperienceForm
+          experience={editingIndex !== null ? experiences[editingIndex] : undefined}
+          onSave={handleSave}
+          onCancel={handleCloseModal}
+        />
+      </Modal>
+
+      <ConfirmDeleteModal
+        open={deleteIndex !== null}
+        onClose={() => setDeleteIndex(null)}
+        onConfirm={confirmDelete}
+        itemName={
+          deleteItem
+            ? `${deleteItem.title}${deleteItem.organization ? ` at ${deleteItem.organization}` : ""}`
+            : undefined
+        }
+      />
+    </>
   );
 }

--- a/src/components/settings/app-preferences-section.tsx
+++ b/src/components/settings/app-preferences-section.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import type { DashboardView, UserPreferences } from "@/types/settings";
 
@@ -7,8 +9,6 @@ type AppPreferencesSectionProps = {
   preferences: UserPreferences;
   onUpdate: <K extends keyof UserPreferences>(key: K, value: UserPreferences[K]) => void;
 };
-
-const labelStyles = "mb-1 block text-xs font-medium text-zinc-400";
 
 const JOB_STAGES = [
   { value: "INTERESTED", label: "Interested" },
@@ -65,9 +65,7 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
 
       <div className="space-y-4">
         <div>
-          <label className={labelStyles} htmlFor="defaultStage">
-            Default stage for new jobs
-          </label>
+          <Label htmlFor="defaultStage">Default stage for new jobs</Label>
           <Select
             id="defaultStage"
             value={preferences.defaultJobStage}
@@ -79,9 +77,7 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
         </div>
 
         <div>
-          <label className={labelStyles} htmlFor="dashboardView">
-            Dashboard view
-          </label>
+          <Label htmlFor="dashboardView">Dashboard view</Label>
           <Select
             id="dashboardView"
             value={preferences.dashboardView}
@@ -106,10 +102,8 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
 
         {preferences.autoArchiveRejected && (
           <div>
-            <label className={labelStyles} htmlFor="archiveDays">
-              Days before auto-archiving
-            </label>
-            <input
+            <Label htmlFor="archiveDays">Days before auto-archiving</Label>
+            <Input
               id="archiveDays"
               type="number"
               min={1}
@@ -121,7 +115,7 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
                   onUpdate("autoArchiveRejectedDays", val);
                 }
               }}
-              className="w-24 bg-zinc-800 border border-zinc-700 rounded-md px-3 py-2 text-sm text-zinc-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              className="w-24"
             />
           </div>
         )}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -25,6 +25,7 @@ export function Input({ id, label, error, required, className = "", ...props }: 
         ].join(" ")}
         aria-invalid={error ? "true" : undefined}
         aria-describedby={error ? `${id}-error` : undefined}
+        required={required}
         {...props}
       />
       {error && (

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -25,6 +25,33 @@ export function Modal({ open, onClose, title, children, maxWidth = "lg" }: Modal
     (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const dialog = dialogRef.current;
+      if (!dialog) return;
+
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey) {
+        if (active === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          event.preventDefault();
+          first.focus();
+        }
       }
     },
     [onClose]

--- a/src/components/ui/skeletons/settings-skeleton.tsx
+++ b/src/components/ui/skeletons/settings-skeleton.tsx
@@ -1,0 +1,51 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SettingsSkeleton() {
+  return (
+    <>
+      <div className="mb-8">
+        <Skeleton className="h-7 w-32 mb-1" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <div className="space-y-8">
+        <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+          <Skeleton className="h-6 w-24 mb-6" />
+          <div className="mb-6 pb-6 border-b border-zinc-800">
+            <Skeleton className="h-4 w-28 mb-2" />
+            <Skeleton className="h-5 w-48" />
+          </div>
+          <div className="flex items-center justify-between">
+            <div>
+              <Skeleton className="h-4 w-20 mb-1" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+            <Skeleton className="h-8 w-32 rounded-md" />
+          </div>
+        </div>
+        <div className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-sm p-6">
+          <Skeleton className="h-6 w-52 mb-4" />
+          <div className="space-y-4">
+            <div>
+              <Skeleton className="h-3 w-36 mb-1" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+            <div>
+              <Skeleton className="h-3 w-28 mb-1" />
+              <Skeleton className="h-9 w-full rounded-md" />
+            </div>
+            <div className="flex items-center justify-between py-3">
+              <div>
+                <Skeleton className="h-4 w-32 mb-1" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+              <Skeleton className="h-6 w-11 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="mt-8 pt-6 border-t border-zinc-800">
+        <Skeleton className="h-9 w-36 rounded-md" />
+      </div>
+    </>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -25,6 +25,7 @@ export function Textarea({ id, label, error, required, className = "", ...props 
         ].join(" ")}
         aria-invalid={error ? "true" : undefined}
         aria-describedby={error ? `${id}-error` : undefined}
+        required={required}
         {...props}
       />
       {error && (

--- a/src/constants/job-stages.ts
+++ b/src/constants/job-stages.ts
@@ -17,3 +17,21 @@ export const STAGE_PRISMA_TO_UI: Record<string, JobStage> = {
   REJECTED: "Rejected",
   ARCHIVED: "Archived",
 };
+
+export const STAGES: JobStage[] = [
+  "Interested",
+  "Applied",
+  "Interview",
+  "Offer",
+  "Rejected",
+  "Archived",
+];
+
+export const STAGE_TEXT_STYLES: Record<JobStage, string> = {
+  Interested: "text-zinc-400",
+  Applied: "text-blue-400",
+  Interview: "text-yellow-400",
+  Offer: "text-green-400",
+  Rejected: "text-red-400",
+  Archived: "text-zinc-500",
+};

--- a/src/hooks/use-view-mode.ts
+++ b/src/hooks/use-view-mode.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ViewMode } from "@/types/job";
+
+const STORAGE_KEY = "dartly-dashboard-view";
+const DEFAULT: ViewMode = "card";
+
+export function useViewMode(): [ViewMode, (mode: ViewMode) => void] {
+  const [mode, setMode] = useState<ViewMode>(DEFAULT);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "card" || stored === "list") setMode(stored);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, mode);
+  }, [mode]);
+
+  return [mode, setMode];
+}

--- a/src/tests/components/auth/login-form.test.tsx
+++ b/src/tests/components/auth/login-form.test.tsx
@@ -13,8 +13,8 @@ describe("LoginForm", () => {
   // Rendering
   it("renders all fields", () => {
     render(<LoginForm />);
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/)).toBeInTheDocument();
   });
 
   it("renders the submit button", () => {
@@ -26,13 +26,13 @@ describe("LoginForm", () => {
   //
   it("uses type=email for email input", () => {
     render(<LoginForm />);
-    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+    expect(screen.getByLabelText(/Email/)).toHaveAttribute("type", "email");
   });
 
   it("marks email and password as required", () => {
     render(<LoginForm />);
-    expect(screen.getByLabelText("Email")).toHaveAttribute("required");
-    expect(screen.getByLabelText("Password")).toHaveAttribute("required");
+    expect(screen.getByLabelText(/Email/)).toHaveAttribute("required");
+    expect(screen.getByLabelText(/Password/)).toHaveAttribute("required");
   });
 
   //invalid credentials
@@ -43,8 +43,8 @@ describe("LoginForm", () => {
     });
 
     render(<LoginForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "wrongpassword");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/Password/), "wrongpassword");
     await userEvent.click(screen.getByRole("button", { name: /login/i }));
     expect(screen.getByText("Invalid email or password.")).toBeInTheDocument();
   });
@@ -58,8 +58,8 @@ describe("LoginForm", () => {
     });
 
     render(<LoginForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/Password/), "Password1!");
     await userEvent.click(screen.getByRole("button", { name: /login/i }));
     expect(mockPush).toHaveBeenCalledWith("/dashboard");
   });

--- a/src/tests/components/auth/register-form.test.tsx
+++ b/src/tests/components/auth/register-form.test.tsx
@@ -13,9 +13,9 @@ describe("RegisterForm", () => {
   // Rendering
   it("renders all fields", () => {
     render(<RegisterForm />);
-    expect(screen.getByLabelText("Email")).toBeInTheDocument();
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
-    expect(screen.getByLabelText("Confirm Password")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Password/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Confirm Password/)).toBeInTheDocument();
   });
 
   it("renders the submit button", () => {
@@ -27,18 +27,18 @@ describe("RegisterForm", () => {
   //simulates a user typing wrong passwords and clicking submit, then checks for the error message
   it("shows error when password is too short", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Ab1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Ab1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Ab1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Ab1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(screen.getByText("Password must be at least 8 characters.")).toBeInTheDocument();
   });
 
   it("shows error when password has no uppercase letter", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "password1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "password1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "password1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "password1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(
       screen.getByText("Password must contain at least one uppercase letter.")
@@ -47,9 +47,9 @@ describe("RegisterForm", () => {
 
   it("shows error when password has no lowercase letter", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "PASSWORD1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "PASSWORD1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "PASSWORD1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "PASSWORD1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(
       screen.getByText("Password must contain at least one lowercase letter.")
@@ -58,18 +58,18 @@ describe("RegisterForm", () => {
 
   it("shows error when password has no number", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Password!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Password!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Password!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(screen.getByText("Password must contain at least one number.")).toBeInTheDocument();
   });
 
   it("shows error when password has no special character", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password1");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Password1");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Password1");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Password1");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(
       screen.getByText("Password must contain at least one special character.")
@@ -78,9 +78,9 @@ describe("RegisterForm", () => {
 
   it("shows error when passwords do not match", async () => {
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "test@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Different1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "test@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Different1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(screen.getByText("Passwords do not match.")).toBeInTheDocument();
   });
@@ -94,9 +94,9 @@ describe("RegisterForm", () => {
     });
 
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "existing@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "existing@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Password1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(screen.getByText("An account with this email already exists.")).toBeInTheDocument();
   });
@@ -110,9 +110,9 @@ describe("RegisterForm", () => {
     });
 
     render(<RegisterForm />);
-    await userEvent.type(screen.getByLabelText("Email"), "new@test.com");
-    await userEvent.type(screen.getByLabelText("Password"), "Password1!");
-    await userEvent.type(screen.getByLabelText("Confirm Password"), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Email/), "new@test.com");
+    await userEvent.type(screen.getByLabelText(/^Password/), "Password1!");
+    await userEvent.type(screen.getByLabelText(/Confirm Password/), "Password1!");
     await userEvent.click(screen.getByRole("button", { name: /register/i }));
     expect(mockPush).toHaveBeenCalledWith("/profile");
   });

--- a/src/tests/hooks/use-view-mode.test.ts
+++ b/src/tests/hooks/use-view-mode.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useViewMode } from "@/hooks/use-view-mode";
+
+describe("useViewMode", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to card mode", () => {
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current[0]).toBe("card");
+  });
+
+  it("reads persisted mode from localStorage", () => {
+    localStorage.setItem("dartly-dashboard-view", "list");
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current[0]).toBe("list");
+  });
+
+  it("ignores invalid localStorage values", () => {
+    localStorage.setItem("dartly-dashboard-view", "table");
+    const { result } = renderHook(() => useViewMode());
+    expect(result.current[0]).toBe("card");
+  });
+
+  it("updates mode and persists to localStorage", () => {
+    const { result } = renderHook(() => useViewMode());
+    act(() => result.current[1]("list"));
+    expect(result.current[0]).toBe("list");
+    expect(localStorage.getItem("dartly-dashboard-view")).toBe("list");
+  });
+
+  it("can switch back to card mode", () => {
+    localStorage.setItem("dartly-dashboard-view", "list");
+    const { result } = renderHook(() => useViewMode());
+    act(() => result.current[1]("card"));
+    expect(result.current[0]).toBe("card");
+    expect(localStorage.getItem("dartly-dashboard-view")).toBe("card");
+  });
+});

--- a/src/tests/utils/deadline.test.ts
+++ b/src/tests/utils/deadline.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { isOverdue } from "@/utils/deadline";
+
+describe("isOverdue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns true when deadline is before today", () => {
+    vi.setSystemTime("2026-04-13");
+    expect(isOverdue("2026-04-12")).toBe(true);
+  });
+
+  it("returns false when deadline is today", () => {
+    vi.setSystemTime("2026-04-13");
+    expect(isOverdue("2026-04-13")).toBe(false);
+  });
+
+  it("returns false when deadline is in the future", () => {
+    vi.setSystemTime("2026-04-13");
+    expect(isOverdue("2026-04-20")).toBe(false);
+  });
+});

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -16,3 +16,5 @@ export type Job = {
   customNotes?: string;
   priority?: boolean;
 };
+
+export type ViewMode = "card" | "list";

--- a/src/utils/deadline.ts
+++ b/src/utils/deadline.ts
@@ -1,0 +1,3 @@
+export function isOverdue(deadline: string): boolean {
+  return deadline < new Date().toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Summary

- **Card/list view toggle** for the job dashboard with localStorage persistence, compact list rows, and a two-tier FilterBar layout with view toggle buttons
- **Bug fix:** Card title truncation now works correctly (`min-w-0` on flex child)
- **Alignment fix:** Fixed-width stage dropdown, deadline, and priority slots keep list rows aligned
- **ExperienceSection fix:** Wired up broken edit/delete modals (ExperienceForm + ConfirmDeleteModal)
- **Modal focus trap:** Tab key now cycles within open modals
- **ARIA improvements:** Tab panel roles on job detail tabs, `aria-label` on search input, `role="status"` on loading skeleton
- **Consistent stage colors:** Unified `Interview` stage color across job detail badge and shared constants
- **Settings skeleton:** Replaced plain "Loading..." text with animated skeleton matching page layout
- **Reusable Input/Textarea migration:** Replaced raw `<input>`/`<textarea>` in auth forms, job-form, account-section, overview-section, timeline/interviews/followups sections, and app-preferences — gaining `aria-invalid`, `aria-describedby`, and consistent styling
- **Responsive layout:** App layout padding now uses `px-4 sm:px-8`, overview section grids use `sm:` breakpoints
- **Custom Select in overview:** Replaced native `<select>` with the custom `Select` component for visual consistency

## Test plan

- [x] 145 tests passing (5 new: `useViewMode` hook, `isOverdue` utility)
- [x] `bun run type-check` clean
- [x] `bun lint` clean (164 files)
- [x] `bun run build` succeeds
- [x] Manual: verify card/list toggle in browser, check localStorage persists across refresh
- [x] Manual: verify list row alignment with/without priority and deadline
- [x] Manual: verify experience edit/delete modals work on profile page