### PR TITLE
feat(dashboard): stage badge pickers and deadline urgency indicators

### DIFF
--- a/src/components/dashboard/job-card.tsx
+++ b/src/components/dashboard/job-card.tsx
@@ -1,14 +1,9 @@
-// S2-005: Added click-to-navigate to /dashboard/[jobId].
-// Changes from original:
-//   - imports useRouter
-//   - card container gets onClick + cursor-pointer + hover border
-//   - Edit and Delete buttons get e.stopPropagation() so they don't also trigger the card navigation
-
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Select } from "@/components/ui/select";
+import { BadgePicker } from "@/components/ui/badge-picker";
+import { ACTIVE_STAGES, STAGE_STYLES } from "@/constants/job-stages";
 import type { Job, JobStage } from "@/types/job";
-import { isOverdue } from "@/utils/deadline";
+import { getUrgency, URGENCY_STYLES } from "@/utils/deadline";
 
 type JobCardProps = {
   job: Job;
@@ -19,16 +14,10 @@ type JobCardProps = {
   onRestore?: (id: string) => Promise<void>;
 };
 
-const STAGES: JobStage[] = ["Interested", "Applied", "Interview", "Offer", "Rejected"];
-
-const STAGE_TEXT_STYLES: Record<JobStage, string> = {
-  Interested: "text-zinc-400",
-  Applied: "text-blue-400",
-  Interview: "text-yellow-400",
-  Offer: "text-green-400",
-  Rejected: "text-red-400",
-  Archived: "text-zinc-500",
-};
+const STAGE_OPTIONS = ACTIVE_STAGES.map((s) => {
+  const style = STAGE_STYLES[s];
+  return { value: s, label: s, badge: style.badge, dot: style.dot };
+});
 
 export default function JobCard({
   job,
@@ -42,6 +31,9 @@ export default function JobCard({
   const [isChangingStage, setIsChangingStage] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
   const isArchived = job.stage === "Archived";
+
+  const urgency = getUrgency(job.deadline);
+  const urgencyStyle = URGENCY_STYLES[urgency];
 
   async function handleStageChange(val: string) {
     const newStage = val as JobStage;
@@ -205,55 +197,97 @@ export default function JobCard({
       >
         <div className="mt-4 space-y-1 text-sm text-zinc-500">
           {job.location && <p>{job.location}</p>}
-          {job.deadline && (
-            <p className={`whitespace-nowrap${isOverdue(job.deadline) ? " text-red-400" : ""}`}>
-              Deadline: {job.deadline}
-            </p>
-          )}
+          {job.deadline && <p className="whitespace-nowrap">Deadline: {job.deadline}</p>}
           <p className="whitespace-nowrap">Last activity: {job.lastActivityDate}</p>
         </div>
       </button>
 
       <div className="mt-auto flex items-center justify-between pt-4">
         <div className="flex items-center gap-1.5">
-          {!isArchived && (
-            <>
-              {isChangingStage && (
-                <svg
-                  className="animate-spin text-zinc-500"
-                  width="12"
-                  height="12"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2.5"
-                  aria-hidden="true"
-                >
-                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                </svg>
-              )}
-              <Select
-                value={job.stage}
-                onChange={handleStageChange}
-                options={STAGES.map((s) => ({ value: s, label: s }))}
-                className="text-xs font-medium"
-                textClassName={STAGE_TEXT_STYLES[job.stage]}
-              />
-            </>
+          {isChangingStage && (
+            <svg
+              className="animate-spin text-zinc-500"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              aria-hidden="true"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
           )}
 
-          {isArchived && (
-            <span className="rounded-md px-2.5 py-1 text-xs font-medium bg-zinc-900 text-zinc-500">
-              Archived
+          {!isArchived && onStageChange && (
+            <BadgePicker
+              value={job.stage}
+              options={STAGE_OPTIONS}
+              onChange={(val) => handleStageChange(val)}
+              disabled={isChangingStage}
+            />
+          )}
+
+          {(isArchived || !onStageChange) && (
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium ${STAGE_STYLES[job.stage].badge}`}
+            >
+              <span
+                className={`inline-block h-1.5 w-1.5 rounded-full ${STAGE_STYLES[job.stage].dot}`}
+              />
+              {job.stage}
             </span>
           )}
         </div>
 
-        {job.priority && (
-          <span className="bg-yellow-950 text-yellow-400 rounded-md px-2 py-1 text-xs font-medium">
-            Priority
-          </span>
-        )}
+        <div className="flex items-center gap-1.5">
+          {urgency !== "none" && (
+            <span
+              className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${urgencyStyle.badge}`}
+            >
+              {urgency === "overdue" && (
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                  <line x1="12" y1="9" x2="12" y2="13" />
+                  <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+              )}
+              {urgency === "due-soon" && (
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+              )}
+              {urgencyStyle.label}
+            </span>
+          )}
+
+          {job.priority && (
+            <span className="bg-yellow-950 text-yellow-400 rounded-md px-2 py-1 text-xs font-medium">
+              Priority
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/job-list-item.tsx
+++ b/src/components/dashboard/job-list-item.tsx
@@ -2,10 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { Select } from "@/components/ui/select";
-import { STAGE_TEXT_STYLES, STAGES } from "@/constants/job-stages";
+import { BadgePicker } from "@/components/ui/badge-picker";
+import { ACTIVE_STAGES, STAGE_STYLES } from "@/constants/job-stages";
 import type { Job, JobStage } from "@/types/job";
-import { isOverdue } from "@/utils/deadline";
+import { getUrgency, URGENCY_STYLES } from "@/utils/deadline";
 
 type JobListItemProps = {
   job: Job;
@@ -14,9 +14,17 @@ type JobListItemProps = {
   onStageChange?: (id: string, stage: JobStage) => void;
 };
 
+const STAGE_OPTIONS = ACTIVE_STAGES.map((s) => {
+  const style = STAGE_STYLES[s];
+  return { value: s, label: s, badge: style.badge, dot: style.dot };
+});
+
 export default function JobListItem({ job, onEdit, onDelete, onStageChange }: JobListItemProps) {
   const router = useRouter();
   const [isChangingStage, setIsChangingStage] = useState(false);
+
+  const urgency = getUrgency(job.deadline);
+  const urgencyStyle = URGENCY_STYLES[urgency];
 
   async function handleStageChange(val: string) {
     const newStage = val as JobStage;
@@ -50,41 +58,87 @@ export default function JobListItem({ job, onEdit, onDelete, onStageChange }: Jo
           </div>
           <div className="mt-1 flex items-center gap-3 text-xs text-zinc-500">
             {job.location && <span>{job.location}</span>}
-            {job.deadline && (
-              <span
-                className={`whitespace-nowrap${isOverdue(job.deadline) ? " text-red-400" : ""}`}
-              >
-                Deadline: {job.deadline}
-              </span>
-            )}
+            {job.deadline && <span className="whitespace-nowrap">Deadline: {job.deadline}</span>}
             <span className="whitespace-nowrap">Last activity: {job.lastActivityDate}</span>
           </div>
         </button>
 
-        <div className="shrink-0 flex items-center gap-3 pt-0.5">
-          <div className="flex items-center gap-1.5">
-            {isChangingStage && (
-              <svg
-                className="animate-spin text-zinc-500"
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2.5"
-                aria-hidden="true"
-              >
-                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-              </svg>
-            )}
-            <Select
+        <div className="shrink-0 flex items-center gap-2 pt-0.5">
+          {isChangingStage && (
+            <svg
+              className="animate-spin text-zinc-500"
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              aria-hidden="true"
+            >
+              <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+            </svg>
+          )}
+
+          {onStageChange && !isChangingStage && (
+            <BadgePicker
               value={job.stage}
-              onChange={handleStageChange}
-              options={STAGES.map((s) => ({ value: s, label: s }))}
-              className="w-[110px] text-xs font-medium"
-              textClassName={STAGE_TEXT_STYLES[job.stage]}
+              options={STAGE_OPTIONS}
+              onChange={(val) => handleStageChange(val)}
+              disabled={isChangingStage}
             />
-          </div>
+          )}
+
+          {(isChangingStage || !onStageChange) && (
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium ${STAGE_STYLES[job.stage].badge}`}
+            >
+              <span
+                className={`inline-block h-1.5 w-1.5 rounded-full ${STAGE_STYLES[job.stage].dot}`}
+              />
+              {job.stage}
+            </span>
+          )}
+
+          {urgency !== "none" && (
+            <span
+              className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${urgencyStyle.badge}`}
+            >
+              {urgency === "overdue" && (
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+                  <line x1="12" y1="9" x2="12" y2="13" />
+                  <line x1="12" y1="17" x2="12.01" y2="17" />
+                </svg>
+              )}
+              {urgency === "due-soon" && (
+                <svg
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+              )}
+              {urgencyStyle.label}
+            </span>
+          )}
 
           {onEdit && (
             <button

--- a/src/components/ui/badge-picker.tsx
+++ b/src/components/ui/badge-picker.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+type BadgePickerOption = {
+  value: string;
+  label: string;
+  badge: string;
+  dot: string;
+};
+
+type BadgePickerProps = {
+  value: string;
+  options: BadgePickerOption[];
+  onChange: (value: string) => void;
+  disabled?: boolean;
+};
+
+export function BadgePicker({ value, options, onChange, disabled }: BadgePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const id = useId();
+
+  const current = options.find((o) => o.value === value) ?? options[0];
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      const t = e.target as Node;
+      if (triggerRef.current?.contains(t)) return;
+      if (popoverRef.current?.contains(t)) return;
+      setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  function getPopoverStyle(): React.CSSProperties {
+    if (!triggerRef.current) return { display: "none" };
+    const rect = triggerRef.current.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const approxHeight = options.length * 36 + 16;
+    const openAbove = spaceBelow < approxHeight;
+    return {
+      position: "fixed",
+      top: openAbove ? undefined : rect.bottom + 4,
+      bottom: openAbove ? window.innerHeight - rect.top + 4 : undefined,
+      left: rect.left,
+      zIndex: 60,
+    };
+  }
+
+  function handleSelect(val: string) {
+    onChange(val);
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        disabled={disabled}
+        onClick={() => !disabled && setOpen((v) => !v)}
+        className={[
+          `inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-opacity ${current.badge}`,
+          disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer hover:opacity-80",
+        ].join(" ")}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={`Stage: ${current.label}. Click to change.`}
+      >
+        <span className={`inline-block h-1.5 w-1.5 rounded-full ${current.dot}`} />
+        {current.label}
+        <svg
+          className="shrink-0 opacity-50"
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="6 9 12 15 18 9" />
+        </svg>
+      </button>
+
+      {mounted &&
+        open &&
+        !disabled &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            id={`${id}-popover`}
+            role="listbox"
+            className="bg-zinc-900 border border-zinc-700 rounded-lg shadow-2xl py-1 min-w-[140px] animate-[scaleIn_150ms_ease-out]"
+            style={getPopoverStyle()}
+          >
+            {options.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={option.value === value}
+                onClick={() => handleSelect(option.value)}
+                className="w-full text-left px-3 py-1.5 text-sm transition-colors hover:bg-zinc-800 flex items-center gap-2"
+              >
+                <span className={`inline-block h-2 w-2 rounded-full ${option.dot}`} />
+                <span
+                  className={option.value === value ? "text-zinc-100 font-medium" : "text-zinc-300"}
+                >
+                  {option.label}
+                </span>
+                {option.value === value && (
+                  <svg
+                    className="ml-auto text-indigo-400"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/src/constants/job-stages.ts
+++ b/src/constants/job-stages.ts
@@ -27,11 +27,47 @@ export const STAGES: JobStage[] = [
   "Archived",
 ];
 
-export const STAGE_TEXT_STYLES: Record<JobStage, string> = {
-  Interested: "text-zinc-400",
-  Applied: "text-blue-400",
-  Interview: "text-yellow-400",
-  Offer: "text-green-400",
-  Rejected: "text-red-400",
-  Archived: "text-zinc-500",
+export const ACTIVE_STAGES: JobStage[] = STAGES.filter((s) => s !== "Archived");
+
+type StageStyle = {
+  badge: string;
+  dot: string;
+  text: string;
 };
+
+export const STAGE_STYLES: Record<JobStage, StageStyle> = {
+  Interested: {
+    badge: "bg-zinc-800 text-zinc-400 border-zinc-700",
+    dot: "bg-zinc-400",
+    text: "text-zinc-400",
+  },
+  Applied: {
+    badge: "bg-blue-950 text-blue-400 border-blue-800",
+    dot: "bg-blue-400",
+    text: "text-blue-400",
+  },
+  Interview: {
+    badge: "bg-yellow-950 text-yellow-400 border-yellow-800",
+    dot: "bg-yellow-400",
+    text: "text-yellow-400",
+  },
+  Offer: {
+    badge: "bg-green-950 text-green-400 border-green-800",
+    dot: "bg-green-400",
+    text: "text-green-400",
+  },
+  Rejected: {
+    badge: "bg-red-950 text-red-400 border-red-800",
+    dot: "bg-red-400",
+    text: "text-red-400",
+  },
+  Archived: {
+    badge: "bg-zinc-900 text-zinc-500 border-zinc-800",
+    dot: "bg-zinc-500",
+    text: "text-zinc-500",
+  },
+};
+
+export const STAGE_TEXT_STYLES: Record<JobStage, string> = Object.fromEntries(
+  Object.entries(STAGE_STYLES).map(([stage, style]) => [stage, style.text])
+) as Record<JobStage, string>;

--- a/src/tests/utils/deadline.test.ts
+++ b/src/tests/utils/deadline.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { isOverdue } from "@/utils/deadline";
+import { getUrgency, isOverdue } from "@/utils/deadline";
 
 describe("isOverdue", () => {
   beforeEach(() => {
@@ -23,5 +23,40 @@ describe("isOverdue", () => {
   it("returns false when deadline is in the future", () => {
     vi.setSystemTime("2026-04-13");
     expect(isOverdue("2026-04-20")).toBe(false);
+  });
+});
+
+describe("getUrgency", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 'none' when no deadline is provided", () => {
+    expect(getUrgency()).toBe("none");
+    expect(getUrgency(undefined)).toBe("none");
+  });
+
+  it("returns 'overdue' when deadline is in the past", () => {
+    vi.setSystemTime("2026-04-15");
+    expect(getUrgency("2026-04-14")).toBe("overdue");
+    expect(getUrgency("2026-04-10")).toBe("overdue");
+  });
+
+  it("returns 'due-soon' when deadline is within 7 days", () => {
+    vi.setSystemTime("2026-04-15");
+    expect(getUrgency("2026-04-15")).toBe("due-soon");
+    expect(getUrgency("2026-04-16")).toBe("due-soon");
+    expect(getUrgency("2026-04-21")).toBe("due-soon");
+    expect(getUrgency("2026-04-22")).toBe("due-soon");
+  });
+
+  it("returns 'upcoming' when deadline is more than 7 days away", () => {
+    vi.setSystemTime("2026-04-15");
+    expect(getUrgency("2026-04-23")).toBe("upcoming");
+    expect(getUrgency("2026-05-01")).toBe("upcoming");
   });
 });

--- a/src/utils/deadline.ts
+++ b/src/utils/deadline.ts
@@ -1,3 +1,44 @@
-export function isOverdue(deadline: string): boolean {
-  return deadline < new Date().toISOString().slice(0, 10);
+export type Urgency = "overdue" | "due-soon" | "upcoming" | "none";
+
+const DUE_SOON_DAYS = 7;
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10);
 }
+
+function diffDays(a: string, b: string): number {
+  const da = new Date(`${a}T00:00:00Z`);
+  const db = new Date(`${b}T00:00:00Z`);
+  return Math.round((da.getTime() - db.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+export function getUrgency(deadline?: string): Urgency {
+  if (!deadline) return "none";
+  const days = diffDays(deadline, todayStr());
+  if (days < 0) return "overdue";
+  if (days <= DUE_SOON_DAYS) return "due-soon";
+  return "upcoming";
+}
+
+export function isOverdue(deadline: string): boolean {
+  return deadline < todayStr();
+}
+
+export const URGENCY_STYLES: Record<Urgency, { badge: string; label: string }> = {
+  overdue: {
+    badge: "bg-red-950 text-red-400 border-red-800",
+    label: "Overdue",
+  },
+  "due-soon": {
+    badge: "bg-amber-950 text-amber-400 border-amber-800",
+    label: "Due soon",
+  },
+  upcoming: {
+    badge: "bg-zinc-800 text-zinc-400 border-zinc-700",
+    label: "Upcoming",
+  },
+  none: {
+    badge: "",
+    label: "",
+  },
+};


### PR DESCRIPTION
## Summary
- Replace stage `Select` dropdown with clickable `BadgePicker` component (colored badge with dot → popover list)
- Add deadline urgency badges: **Overdue** (red, warning icon) and **Due soon** (amber, clock icon) for deadlines within 7 days
- Consolidate stage styles into `STAGE_STYLES` constant with badge/bg/dot/text per stage
- Add `getUrgency()` utility with timezone-safe date comparison
- Applied consistently to both `job-card.tsx` and `job-list-item.tsx`

Closes #64