### PR TITLE
fix(demo): sprint 2 demo readiness

### DIFF
--- a/src/app/(app)/dashboard/[jobId]/page.tsx
+++ b/src/app/(app)/dashboard/[jobId]/page.tsx
@@ -185,27 +185,6 @@ export default function JobDetailPage({ params }: { params: Promise<{ jobId: str
           />
         </div>
       )}
-      {activeTab === "timeline" && (
-        <TimelineSection
-          activities={activities}
-          jobId={job.id}
-          onActivitiesChanged={fetchActivities}
-        />
-      )}
-      {activeTab === "interviews" && (
-        <InterviewsSection
-          activities={activities.filter((a) => a.type === "INTERVIEW")}
-          jobId={job.id}
-          onActivitiesChanged={fetchActivities}
-        />
-      )}
-      {activeTab === "followups" && (
-        <FollowUpsSection
-          activities={activities.filter((a) => a.type === "FOLLOWUP")}
-          jobId={job.id}
-          onActivitiesChanged={fetchActivities}
-        />
-      )}
     </div>
   );
 }

--- a/src/scripts/clean-seed.ts
+++ b/src/scripts/clean-seed.ts
@@ -12,17 +12,62 @@ async function main() {
     ["User A", USER_A],
     ["User B", USER_B],
   ]) {
-    console.log(`\n🧹 Cleaning jobs for ${label} (${userId.slice(0, 8)}...)`);
+    console.log(`\n🧹 Cleaning data for ${label} (${userId.slice(0, 8)}...)`);
 
-    const result = await prisma.job.deleteMany({
+    const skills = await prisma.skill.deleteMany({
+      where: { profile: { userId } },
+    });
+    totalDeleted += skills.count;
+
+    const educations = await prisma.education.deleteMany({
+      where: { profile: { userId } },
+    });
+    totalDeleted += educations.count;
+
+    const experiences = await prisma.experience.deleteMany({
+      where: { profile: { userId } },
+    });
+    totalDeleted += experiences.count;
+
+    const profile = await prisma.profile.deleteMany({
       where: { userId },
     });
+    totalDeleted += profile.count;
 
-    totalDeleted += result.count;
-    console.log(`  ✅ Deleted ${result.count} jobs`);
+    const docLinks = await prisma.jobDocumentLink.deleteMany({
+      where: { job: { userId } },
+    });
+    totalDeleted += docLinks.count;
+
+    const docVersions = await prisma.documentVersion.deleteMany({
+      where: { document: { userId } },
+    });
+    totalDeleted += docVersions.count;
+
+    const documents = await prisma.document.deleteMany({
+      where: { userId },
+    });
+    totalDeleted += documents.count;
+
+    const activities = await prisma.jobActivity.deleteMany({
+      where: { job: { userId } },
+    });
+    totalDeleted += activities.count;
+
+    const stageHistory = await prisma.jobStageHistory.deleteMany({
+      where: { job: { userId } },
+    });
+    totalDeleted += stageHistory.count;
+
+    const jobs = await prisma.job.deleteMany({
+      where: { userId },
+    });
+    totalDeleted += jobs.count;
+
+    console.log(`  ✅ Deleted all data for ${label}`);
   }
 
-  console.log(`\n✨ Clean complete! Total deleted: ${totalDeleted} jobs`);
+  console.log(`\n✨ Clean complete! Total records deleted: ${totalDeleted}`);
 }
 
 main()

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -1,3 +1,4 @@
+import type { JobStage } from "@prisma/client";
 import { prisma } from "@/services/prisma";
 
 const USER_A = "a818c364-412a-4545-8c88-f7b4cba05307";
@@ -48,6 +49,15 @@ const USER_A_JOBS = [
     priority: false,
     description: "Early-stage startup, equity opportunity",
     applicationDate: new Date("2024-03-28"),
+  },
+  {
+    title: "QA Engineer",
+    company: "TestLab",
+    location: "Portland, OR",
+    stage: "REJECTED" as const,
+    priority: false,
+    description: "Automated testing and CI quality gates",
+    applicationDate: new Date("2024-03-05"),
   },
 ];
 
@@ -126,6 +136,247 @@ const USER_B_JOBS = [
   },
 ];
 
+const PROFILES: Record<
+  string,
+  {
+    firstName: string;
+    lastName: string;
+    email: string;
+    phone: string;
+    location: string;
+    headline: string;
+    summary: string;
+    experiences: {
+      type: "EMPLOYMENT" | "PROJECT";
+      title: string;
+      organization: string | null;
+      startDate: Date | null;
+      endDate: Date | null;
+      isCurrent: boolean;
+      description: string | null;
+      order: number;
+    }[];
+    educations: {
+      institution: string;
+      degree: string | null;
+      fieldOfStudy: string | null;
+      startDate: Date | null;
+      endDate: Date | null;
+      gpa: string | null;
+    }[];
+    skills: { name: string; category: string | null; proficiency: string | null; order: number }[];
+  }
+> = {
+  [USER_A]: {
+    firstName: "Alex",
+    lastName: "Rivera",
+    email: "alex.rivera@email.com",
+    phone: "(555) 123-4567",
+    location: "San Francisco, CA",
+    headline: "Full Stack Software Engineer",
+    summary:
+      "Experienced software engineer with 4+ years building scalable web applications. Passionate about clean architecture, developer experience, and shipping products that solve real problems. Strong background in TypeScript, React, and Node.js.",
+    experiences: [
+      {
+        type: "EMPLOYMENT",
+        title: "Software Engineer",
+        organization: "TechNova Inc.",
+        startDate: new Date("2022-06-01"),
+        endDate: null,
+        isCurrent: true,
+        description:
+          "Full stack development on a B2B SaaS platform serving 50k+ users. Led migration from REST to GraphQL, reducing API payload size by 40%. Mentored 2 junior engineers.",
+        order: 0,
+      },
+      {
+        type: "EMPLOYMENT",
+        title: "Junior Developer",
+        organization: "WebForge LLC",
+        startDate: new Date("2020-08-01"),
+        endDate: new Date("2022-05-01"),
+        isCurrent: false,
+        description:
+          "Built and maintained client-facing dashboards using React and TypeScript. Implemented automated CI/CD pipelines reducing deployment time by 60%.",
+        order: 1,
+      },
+      {
+        type: "PROJECT",
+        title: "Open Source CLI Tool",
+        organization: null,
+        startDate: new Date("2023-01-01"),
+        endDate: new Date("2023-06-01"),
+        isCurrent: false,
+        description:
+          "Created and published a developer productivity CLI with 500+ GitHub stars. Written in TypeScript with comprehensive test coverage.",
+        order: 2,
+      },
+    ],
+    educations: [
+      {
+        institution: "New Jersey Institute of Technology",
+        degree: "B.S.",
+        fieldOfStudy: "Computer Science",
+        startDate: new Date("2016-09-01"),
+        endDate: new Date("2020-05-01"),
+        gpa: "3.7",
+      },
+      {
+        institution: "Hudson County Community College",
+        degree: "A.S.",
+        fieldOfStudy: "Computer Science",
+        startDate: new Date("2014-09-01"),
+        endDate: new Date("2016-05-01"),
+        gpa: "3.8",
+      },
+    ],
+    skills: [
+      { name: "TypeScript", category: "Languages", proficiency: "Advanced", order: 0 },
+      { name: "React", category: "Frameworks", proficiency: "Advanced", order: 1 },
+      { name: "Node.js", category: "Runtime", proficiency: "Advanced", order: 2 },
+      { name: "PostgreSQL", category: "Databases", proficiency: "Intermediate", order: 3 },
+      { name: "Docker", category: "DevOps", proficiency: "Intermediate", order: 4 },
+      { name: "GraphQL", category: "API", proficiency: "Intermediate", order: 5 },
+    ],
+  },
+  [USER_B]: {
+    firstName: "Jordan",
+    lastName: "Kim",
+    email: "jordan.kim@email.com",
+    phone: "(555) 987-6543",
+    location: "Seattle, WA",
+    headline: "Senior Platform Engineer",
+    summary:
+      "Platform engineer with 6+ years of experience in distributed systems, cloud infrastructure, and developer tooling. Focused on building reliable, scalable backend systems. AWS certified with deep Kubernetes expertise.",
+    experiences: [
+      {
+        type: "EMPLOYMENT",
+        title: "Senior Backend Engineer",
+        organization: "CloudScale Systems",
+        startDate: new Date("2021-03-01"),
+        endDate: null,
+        isCurrent: true,
+        description:
+          "Architected event-driven microservices processing 10M+ events/day. Reduced infrastructure costs by 35% through right-sizing and spot instance optimization. Led on-call rotation for critical services.",
+        order: 0,
+      },
+      {
+        type: "EMPLOYMENT",
+        title: "Backend Developer",
+        organization: "DataPipe Corp",
+        startDate: new Date("2018-07-01"),
+        endDate: new Date("2021-02-01"),
+        isCurrent: false,
+        description:
+          "Built real-time data processing pipelines using Kafka and Go. Designed and implemented a custom job scheduler handling 100k+ scheduled tasks daily.",
+        order: 1,
+      },
+    ],
+    educations: [
+      {
+        institution: "University of Washington",
+        degree: "M.S.",
+        fieldOfStudy: "Computer Science",
+        startDate: new Date("2016-09-01"),
+        endDate: new Date("2018-06-01"),
+        gpa: "3.9",
+      },
+      {
+        institution: "Rutgers University",
+        degree: "B.S.",
+        fieldOfStudy: "Computer Engineering",
+        startDate: new Date("2012-09-01"),
+        endDate: new Date("2016-05-01"),
+        gpa: "3.6",
+      },
+    ],
+    skills: [
+      { name: "Go", category: "Languages", proficiency: "Advanced", order: 0 },
+      { name: "Python", category: "Languages", proficiency: "Advanced", order: 1 },
+      { name: "Kubernetes", category: "Infrastructure", proficiency: "Advanced", order: 2 },
+      { name: "AWS", category: "Cloud", proficiency: "Advanced", order: 3 },
+      { name: "Kafka", category: "Messaging", proficiency: "Intermediate", order: 4 },
+      { name: "Terraform", category: "DevOps", proficiency: "Advanced", order: 5 },
+    ],
+  },
+};
+
+const STAGE_TRANSITIONS: Record<string, { from: string | null; to: string }[]> = {
+  APPLIED: [{ from: null, to: "APPLIED" }],
+  INTERVIEW: [
+    { from: null, to: "APPLIED" },
+    { from: "APPLIED", to: "INTERVIEW" },
+  ],
+  OFFER: [
+    { from: null, to: "APPLIED" },
+    { from: "APPLIED", to: "INTERVIEW" },
+    { from: "INTERVIEW", to: "OFFER" },
+  ],
+  REJECTED: [
+    { from: null, to: "APPLIED" },
+    { from: "APPLIED", to: "REJECTED" },
+  ],
+  INTERESTED: [{ from: null, to: "INTERESTED" }],
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  INTERESTED: "Interested",
+  APPLIED: "Applied",
+  INTERVIEW: "Interview",
+  OFFER: "Offer",
+  REJECTED: "Rejected",
+};
+
+function getActivityDateForStage(_stage: string, transitionIndex: number, baseDate: Date): Date {
+  const daysOffset = transitionIndex * 5;
+  const d = new Date(baseDate);
+  d.setDate(d.getDate() + daysOffset);
+  return d;
+}
+
+async function seedProfile(userId: string, userLabel: string) {
+  const data = PROFILES[userId];
+  if (!data) return;
+
+  console.log(`\n🌱 Seeding profile for ${userLabel}`);
+
+  const profile = await prisma.profile.upsert({
+    where: { userId },
+    update: {},
+    create: {
+      userId,
+      firstName: data.firstName,
+      lastName: data.lastName,
+      email: data.email,
+      phone: data.phone,
+      location: data.location,
+      headline: data.headline,
+      summary: data.summary,
+    },
+  });
+
+  for (const exp of data.experiences) {
+    await prisma.experience.create({
+      data: { profileId: profile.id, ...exp },
+    });
+  }
+
+  for (const edu of data.educations) {
+    await prisma.education.create({
+      data: { profileId: profile.id, ...edu },
+    });
+  }
+
+  for (const skill of data.skills) {
+    await prisma.skill.create({
+      data: { profileId: profile.id, ...skill },
+    });
+  }
+
+  console.log(
+    `  ✅ Profile: ${data.experiences.length} experiences, ${data.educations.length} educations, ${data.skills.length} skills`
+  );
+}
+
 async function seedJobs(userId: string, jobs: typeof USER_A_JOBS, userLabel: string) {
   console.log(`\n🌱 Seeding ${jobs.length} jobs for ${userLabel} (${userId.slice(0, 8)}...)`);
 
@@ -134,10 +385,103 @@ async function seedJobs(userId: string, jobs: typeof USER_A_JOBS, userLabel: str
       const job = await prisma.job.create({
         data: {
           userId,
-          ...jobData,
+          title: jobData.title,
+          company: jobData.company,
+          location: jobData.location,
+          stage: jobData.stage,
+          priority: jobData.priority,
+          description: jobData.description,
+          applicationDate: jobData.applicationDate,
           lastActivityAt: jobData.applicationDate || new Date(),
         },
       });
+
+      const transitions = STAGE_TRANSITIONS[jobData.stage] ?? [{ from: null, to: jobData.stage }];
+      const baseDate = jobData.applicationDate ?? new Date("2024-03-01");
+
+      for (let i = 0; i < transitions.length; i++) {
+        const t = transitions[i];
+        await prisma.jobStageHistory.create({
+          data: {
+            jobId: job.id,
+            fromStage: t.from as JobStage | null,
+            toStage: t.to as JobStage,
+            changedAt: getActivityDateForStage(jobData.stage, i, baseDate),
+          },
+        });
+
+        if (t.from !== null) {
+          const fromLabel = STAGE_LABELS[t.from] ?? t.from;
+          const toLabel = STAGE_LABELS[t.to] ?? t.to;
+          await prisma.jobActivity.create({
+            data: {
+              jobId: job.id,
+              type: "STAGE",
+              title: `Stage changed: ${fromLabel} → ${toLabel}`,
+              createdAt: getActivityDateForStage(jobData.stage, i, baseDate),
+            },
+          });
+        }
+      }
+
+      if (jobData.stage === "INTERVIEW") {
+        const interviewBase = new Date(baseDate);
+        interviewBase.setDate(interviewBase.getDate() + 7);
+        await prisma.jobActivity.create({
+          data: {
+            jobId: job.id,
+            type: "INTERVIEW",
+            title: "Technical Phone Screen",
+            description: "45-min technical interview covering system design and coding",
+            roundType: "PHONE_SCREEN",
+            scheduledAt: interviewBase,
+            completed: true,
+            createdAt: interviewBase,
+          },
+        });
+        const onsite = new Date(interviewBase);
+        onsite.setDate(onsite.getDate() + 5);
+        await prisma.jobActivity.create({
+          data: {
+            jobId: job.id,
+            type: "INTERVIEW",
+            title: "Onsite Interview Loop",
+            description:
+              "Full day: 4 rounds including system design, coding, behavioral, and hiring manager",
+            roundType: "ONSITE",
+            scheduledAt: onsite,
+            completed: false,
+            createdAt: onsite,
+          },
+        });
+      }
+
+      if (jobData.stage === "APPLIED" || jobData.stage === "INTERVIEW") {
+        const followUpDate = new Date(baseDate);
+        followUpDate.setDate(followUpDate.getDate() + 10);
+        await prisma.jobActivity.create({
+          data: {
+            jobId: job.id,
+            type: "FOLLOWUP",
+            title: "Follow up on application status",
+            description: "Send polite follow-up email to recruiter",
+            scheduledAt: followUpDate,
+            completed: false,
+            createdAt: followUpDate,
+          },
+        });
+      }
+
+      await prisma.jobActivity.create({
+        data: {
+          jobId: job.id,
+          type: "NOTE",
+          title: "Application submitted",
+          description: `Applied to ${jobData.company} for ${jobData.title} position`,
+          createdAt: baseDate,
+        },
+      });
+
       console.log(`  ✅ Created: ${job.title} at ${job.company} (${job.stage})`);
     } catch (error) {
       console.error(`  ❌ Failed to create ${jobData.title}:`, error);
@@ -145,15 +489,102 @@ async function seedJobs(userId: string, jobs: typeof USER_A_JOBS, userLabel: str
   }
 }
 
+async function seedDocuments(userId: string, userLabel: string) {
+  console.log(`\n🌱 Seeding documents for ${userLabel}`);
+
+  const jobs = await prisma.job.findMany({ where: { userId }, take: 3 });
+  const profile = await prisma.profile.findUnique({ where: { userId } });
+
+  if (!profile || jobs.length === 0) {
+    console.log("  ⚠️  Skipping documents (no profile or jobs found)");
+    return;
+  }
+
+  const firstName = profile.firstName ?? "Candidate";
+  const lastName = profile.lastName ?? "";
+  const fullName = `${firstName} ${lastName}`.trim();
+  const contactLine = [profile.email, profile.phone, profile.location].filter(Boolean).join(" | ");
+
+  for (let i = 0; i < Math.min(jobs.length, 2); i++) {
+    const job = jobs[i];
+
+    const resumeDoc = await prisma.document.create({
+      data: {
+        userId,
+        type: "RESUME",
+        name: `Resume - ${job.company}`,
+        status: "DRAFT",
+      },
+    });
+    const resumeVersion = await prisma.documentVersion.create({
+      data: {
+        documentId: resumeDoc.id,
+        versionNumber: 1,
+        content: `# ${fullName}\n${contactLine}\n\n## Professional Summary\nTailored for ${job.title} at ${job.company}. ${profile.summary ?? ""}\n\n## Experience\n_See profile for full details._\n\n## Skills\n_See profile for full details._`,
+      },
+    });
+    await prisma.jobDocumentLink.create({
+      data: { jobId: job.id, documentId: resumeDoc.id, documentVersionId: resumeVersion.id },
+    });
+
+    const coverDoc = await prisma.document.create({
+      data: {
+        userId,
+        type: "COVER_LETTER",
+        name: `Cover Letter - ${job.company}`,
+        status: "DRAFT",
+      },
+    });
+    const coverVersion = await prisma.documentVersion.create({
+      data: {
+        documentId: coverDoc.id,
+        versionNumber: 1,
+        content: `Dear Hiring Manager at ${job.company},\n\nI am writing to express my interest in the ${job.title} position. With my background in software engineering, I believe I would be a strong fit for this role.\n\nThank you for your consideration.\n\nBest regards,\n${fullName}`,
+      },
+    });
+    await prisma.jobDocumentLink.create({
+      data: { jobId: job.id, documentId: coverDoc.id, documentVersionId: coverVersion.id },
+    });
+
+    console.log(`  ✅ Created resume + cover letter for ${job.title} at ${job.company}`);
+  }
+}
+
 async function main() {
   console.log("=== Dartly Demo Seed Script ===");
 
+  await seedProfile(USER_A, "User A");
+  await seedProfile(USER_B, "User B");
   await seedJobs(USER_A, USER_A_JOBS, "User A");
   await seedJobs(USER_B, USER_B_JOBS, "User B");
+  await seedDocuments(USER_A, "User A");
+  await seedDocuments(USER_B, "User B");
+
+  const counts = {
+    jobs: await prisma.job.count(),
+    profiles: await prisma.profile.count(),
+    experiences: await prisma.experience.count(),
+    educations: await prisma.education.count(),
+    skills: await prisma.skill.count(),
+    activities: await prisma.jobActivity.count(),
+    stageHistory: await prisma.jobStageHistory.count(),
+    documents: await prisma.document.count(),
+    documentVersions: await prisma.documentVersion.count(),
+    documentLinks: await prisma.jobDocumentLink.count(),
+  };
 
   console.log("\n✨ Seed complete!");
-  console.log(`   User A: ${USER_A_JOBS.length} jobs`);
-  console.log(`   User B: ${USER_B_JOBS.length} jobs`);
+  console.log("   Summary:");
+  console.log(`   Jobs:             ${counts.jobs}`);
+  console.log(`   Profiles:         ${counts.profiles}`);
+  console.log(`   Experiences:      ${counts.experiences}`);
+  console.log(`   Educations:       ${counts.educations}`);
+  console.log(`   Skills:           ${counts.skills}`);
+  console.log(`   Activities:       ${counts.activities}`);
+  console.log(`   Stage History:    ${counts.stageHistory}`);
+  console.log(`   Documents:        ${counts.documents}`);
+  console.log(`   Document Versions:${counts.documentVersions}`);
+  console.log(`   Document Links:   ${counts.documentLinks}`);
 }
 
 main()

--- a/src/services/jobs.ts
+++ b/src/services/jobs.ts
@@ -3,6 +3,15 @@ import { STAGE_PRISMA_TO_UI, STAGE_UI_TO_PRISMA } from "@/constants/job-stages";
 import { prisma } from "@/services/prisma";
 import type { Job, JobStage } from "@/types/job";
 
+const STAGE_LABELS: Record<string, string> = {
+  INTERESTED: "Interested",
+  APPLIED: "Applied",
+  INTERVIEW: "Interview",
+  OFFER: "Offer",
+  REJECTED: "Rejected",
+  ARCHIVED: "Archived",
+};
+
 type CreateJobInput = {
   userId: string;
   title: string;
@@ -120,7 +129,6 @@ export async function updateJob(id: string, userId: string, data: UpdateJobInput
         ...(data.customNotes !== undefined && { customNotes: data.customNotes }),
         ...(prismaStage !== undefined && { stage: prismaStage }),
         ...(data.priority !== undefined && { priority: data.priority }),
-        ...(data.customNotes !== undefined && { customNotes: data.customNotes }),
         // Bumped on every save to surface "recently touched" jobs at the top of the
         // dashboard. Intentionally not gated on field changes.
         lastActivityAt: new Date(),
@@ -133,6 +141,16 @@ export async function updateJob(id: string, userId: string, data: UpdateJobInput
           jobId: id,
           fromStage: existing.stage,
           toStage: prismaStage,
+        },
+      });
+
+      const fromLabel = STAGE_LABELS[existing.stage] ?? existing.stage;
+      const toLabel = STAGE_LABELS[prismaStage] ?? prismaStage;
+      await tx.jobActivity.create({
+        data: {
+          jobId: id,
+          type: "STAGE",
+          title: `Stage changed: ${fromLabel} → ${toLabel}`,
         },
       });
     }

--- a/src/tests/api/jobs-activities.test.ts
+++ b/src/tests/api/jobs-activities.test.ts
@@ -1,0 +1,130 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockVerifyJobOwnership, mockGetActivities, mockCreateActivity, mockRequireAuth } =
+  vi.hoisted(() => ({
+    mockVerifyJobOwnership: vi.fn(),
+    mockGetActivities: vi.fn(),
+    mockCreateActivity: vi.fn(),
+    mockRequireAuth: vi.fn(),
+  }));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/services/activities", () => ({
+  verifyJobOwnership: mockVerifyJobOwnership,
+  getActivities: mockGetActivities,
+  createActivity: mockCreateActivity,
+}));
+
+import { GET, POST } from "@/app/api/jobs/[id]/activities/route";
+
+const mockUser = { id: "user-123" };
+const context = { params: Promise.resolve({ id: "job-1" }) };
+
+function makeRequest(body?: object): NextRequest {
+  return new Request("http://localhost/api/jobs/job-1/activities", {
+    method: body ? "POST" : "GET",
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as NextRequest;
+}
+
+describe("GET /api/jobs/[id]/activities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 200 with activities", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(true);
+    const activities = [{ id: "a1", type: "NOTE", title: "Applied", jobId: "job-1" }];
+    mockGetActivities.mockResolvedValue(activities);
+
+    const res = await GET(makeRequest(), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(activities);
+  });
+
+  it("returns 404 when job not found or not owned", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(false);
+
+    const res = await GET(makeRequest(), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Job not found");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await GET(makeRequest(), context);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/jobs/[id]/activities", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 201 with created activity", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(true);
+    const created = { id: "a1", type: "INTERVIEW", title: "Phone Screen", jobId: "job-1" };
+    mockCreateActivity.mockResolvedValue(created);
+
+    const res = await POST(makeRequest({ type: "INTERVIEW", title: "Phone Screen" }), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body).toEqual(created);
+  });
+
+  it("returns 404 when job not found or not owned", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(false);
+
+    const res = await POST(makeRequest({ type: "NOTE", title: "Test" }), context);
+
+    expect(res.status).toBe(404);
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when type is invalid", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(true);
+
+    const res = await POST(makeRequest({ type: "INVALID", title: "Test" }), context);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    mockVerifyJobOwnership.mockResolvedValue(true);
+
+    const res = await POST(makeRequest({ type: "NOTE" }), context);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await POST(makeRequest({ type: "NOTE", title: "Test" }), context);
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/tests/api/jobs.test.ts
+++ b/src/tests/api/jobs.test.ts
@@ -1,0 +1,149 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetJobsByUserId, mockCreateJob, mockToJobResponse, mockRequireAuth } = vi.hoisted(
+  () => ({
+    mockGetJobsByUserId: vi.fn(),
+    mockCreateJob: vi.fn(),
+    mockToJobResponse: vi.fn(),
+    mockRequireAuth: vi.fn(),
+  })
+);
+
+const mockValidatedData = { value: null as unknown };
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/validate-body", () => ({
+  validateBody: vi.fn(async (_req: unknown, _schema: unknown) => mockValidatedData.value),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+  logError: vi.fn(),
+}));
+
+vi.mock("@/services/jobs", () => ({
+  getJobsByUserId: mockGetJobsByUserId,
+  createJob: mockCreateJob,
+  toJobResponse: mockToJobResponse,
+}));
+
+import { GET, POST } from "@/app/api/jobs/route";
+
+const mockUser = { id: "user-123" };
+
+function makeRequest(body?: object): NextRequest {
+  return new Request("http://localhost/api/jobs", {
+    method: body ? "POST" : "GET",
+    headers: body ? { "Content-Type": "application/json" } : undefined,
+    body: body ? JSON.stringify(body) : undefined,
+  }) as unknown as NextRequest;
+}
+
+describe("GET /api/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 200 with empty array when no jobs", async () => {
+    mockGetJobsByUserId.mockResolvedValue([]);
+    mockToJobResponse.mockReturnValue;
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual([]);
+  });
+
+  it("returns 200 with mapped jobs", async () => {
+    const prismaJobs = [
+      { id: "j1", title: "Engineer", stage: "APPLIED" },
+      { id: "j2", title: "Dev", stage: "INTERVIEW" },
+    ];
+    const mapped = [
+      { id: "j1", title: "Engineer", stage: "Applied" },
+      { id: "j2", title: "Dev", stage: "Interview" },
+    ];
+    mockGetJobsByUserId.mockResolvedValue(prismaJobs);
+    mockToJobResponse.mockImplementation((j: { id: string }) => mapped.find((m) => m.id === j.id));
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual(mapped);
+    expect(mockGetJobsByUserId).toHaveBeenCalledWith("user-123");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/jobs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 201 with created job", async () => {
+    const inputData = { title: "Engineer", company: "Acme" };
+    const created = { id: "j1", title: "Engineer", company: "Acme", stage: "INTERESTED" };
+    const mapped = { id: "j1", title: "Engineer", company: "Acme", stage: "Interested" };
+    mockValidatedData.value = inputData;
+    mockCreateJob.mockResolvedValue(created);
+    mockToJobResponse.mockReturnValue(mapped);
+
+    const res = await POST(makeRequest(inputData));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body).toEqual(mapped);
+    expect(mockCreateJob).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "user-123", title: "Engineer", company: "Acme" })
+    );
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    const { validateBody } = await import("@/lib/validate-body");
+    (validateBody as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(400, "Title is required")
+    );
+
+    const res = await POST(makeRequest({ company: "Acme" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when company is missing", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    const { validateBody } = await import("@/lib/validate-body");
+    (validateBody as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new ApiError(400, "Company is required")
+    );
+
+    const res = await POST(makeRequest({ title: "Engineer" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await POST(makeRequest({ title: "Engineer", company: "Acme" }));
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/tests/services/activities.test.ts
+++ b/src/tests/services/activities.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockJobFindFirst = vi.fn();
+const mockActivityFindFirst = vi.fn();
+const mockFindMany = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/services/prisma", () => ({
+  prisma: {
+    job: { findFirst: mockJobFindFirst },
+    jobActivity: {
+      findMany: mockFindMany,
+      findFirst: mockActivityFindFirst,
+      create: mockCreate,
+      update: mockUpdate,
+      delete: mockDelete,
+    },
+  },
+}));
+
+describe("verifyJobOwnership", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns true when job belongs to user", async () => {
+    const { verifyJobOwnership } = await import("@/services/activities");
+    mockJobFindFirst.mockResolvedValue({ id: "j1" });
+
+    const result = await verifyJobOwnership("j1", "u1");
+    expect(result).toBe(true);
+    expect(mockJobFindFirst).toHaveBeenCalledWith({
+      where: { id: "j1", userId: "u1" },
+      select: { id: true },
+    });
+  });
+
+  it("returns false when job does not belong to user", async () => {
+    const { verifyJobOwnership } = await import("@/services/activities");
+    mockJobFindFirst.mockResolvedValue(null);
+
+    const result = await verifyJobOwnership("j1", "u1");
+    expect(result).toBe(false);
+  });
+});
+
+describe("getActivities", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns activities ordered newest first", async () => {
+    const { getActivities } = await import("@/services/activities");
+    const mockActivities = [
+      { id: "a2", type: "NOTE", title: "Second", createdAt: new Date("2026-02-01") },
+      { id: "a1", type: "INTERVIEW", title: "First", createdAt: new Date("2026-01-01") },
+    ];
+    mockFindMany.mockResolvedValue(mockActivities);
+
+    const result = await getActivities("j1");
+    expect(result).toEqual(mockActivities);
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { jobId: "j1" },
+      orderBy: { createdAt: "desc" },
+    });
+  });
+});
+
+describe("createActivity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("creates activity with all fields", async () => {
+    const { createActivity } = await import("@/services/activities");
+    const mockActivity = { id: "a1", jobId: "j1", type: "INTERVIEW", title: "Phone Screen" };
+    mockCreate.mockResolvedValue(mockActivity);
+
+    const result = await createActivity("j1", {
+      type: "INTERVIEW",
+      title: "Phone Screen",
+      description: "Technical round",
+      scheduledAt: "2026-04-01T10:00:00Z",
+      roundType: "PHONE_SCREEN",
+      completed: false,
+    });
+
+    expect(result).toEqual(mockActivity);
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        jobId: "j1",
+        type: "INTERVIEW",
+        title: "Phone Screen",
+        description: "Technical round",
+        roundType: "PHONE_SCREEN",
+        completed: false,
+      }),
+    });
+  });
+
+  it("creates activity with minimal fields", async () => {
+    const { createActivity } = await import("@/services/activities");
+    mockCreate.mockResolvedValue({ id: "a2" });
+
+    await createActivity("j1", { type: "NOTE", title: "Note" });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        jobId: "j1",
+        type: "NOTE",
+        title: "Note",
+        description: null,
+        scheduledAt: null,
+        roundType: null,
+        completed: false,
+      }),
+    });
+  });
+});
+
+describe("updateActivity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("updates activity fields", async () => {
+    const { updateActivity } = await import("@/services/activities");
+    const existing = {
+      id: "a1",
+      jobId: "j1",
+      title: "Old",
+      description: "desc",
+      scheduledAt: null,
+      roundType: null,
+      completed: false,
+    };
+    mockActivityFindFirst.mockResolvedValue(existing);
+    mockUpdate.mockResolvedValue({ ...existing, title: "New" });
+
+    const _result = await updateActivity("a1", "j1", { title: "New" });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: "a1" },
+      data: expect.objectContaining({ title: "New" }),
+    });
+  });
+
+  it("returns null when activity not found or wrong job", async () => {
+    const { updateActivity } = await import("@/services/activities");
+    mockActivityFindFirst.mockResolvedValue(null);
+
+    const result = await updateActivity("a1", "j1", { title: "X" });
+    expect(result).toBeNull();
+  });
+});
+
+describe("deleteActivity", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("deletes activity that belongs to job", async () => {
+    const { deleteActivity } = await import("@/services/activities");
+    mockActivityFindFirst.mockResolvedValue({ id: "a1", jobId: "j1" });
+    mockDelete.mockResolvedValue({ id: "a1" });
+
+    const _result = await deleteActivity("a1", "j1");
+    expect(mockDelete).toHaveBeenCalledWith({ where: { id: "a1" } });
+  });
+
+  it("returns null when activity not found or wrong job", async () => {
+    const { deleteActivity } = await import("@/services/activities");
+    mockActivityFindFirst.mockResolvedValue(null);
+
+    const result = await deleteActivity("a1", "j1");
+    expect(result).toBeNull();
+  });
+});

--- a/src/tests/services/jobs.test.ts
+++ b/src/tests/services/jobs.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockJobCreate = vi.fn();
+const mockJobFindFirst = vi.fn();
+const mockJobUpdate = vi.fn();
+const mockStageHistoryCreate = vi.fn();
+const mockActivityCreate = vi.fn();
+const mockTx = {
+  job: { create: mockJobCreate, update: mockJobUpdate, findFirst: vi.fn() },
+  jobStageHistory: { create: mockStageHistoryCreate },
+  jobActivity: { create: mockActivityCreate },
+};
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/services/prisma", () => ({
+  prisma: {
+    $transaction: vi.fn((fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+    job: {
+      findFirst: mockJobFindFirst,
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+  },
+}));
+
+describe("createJob", () => {
+  it("creates job with initial stage history", async () => {
+    const { createJob } = await import("@/services/jobs");
+
+    const mockCreated = { id: "job-1", stage: "INTERESTED", createdAt: new Date() };
+    mockJobCreate.mockResolvedValue(mockCreated);
+    mockStageHistoryCreate.mockResolvedValue({});
+
+    await createJob({
+      userId: "user-1",
+      title: "Engineer",
+      company: "Acme",
+    });
+
+    expect(mockJobCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: "user-1",
+          title: "Engineer",
+          company: "Acme",
+          stage: "INTERESTED",
+        }),
+      })
+    );
+    expect(mockStageHistoryCreate).toHaveBeenCalledWith({
+      data: { jobId: "job-1", fromStage: null, toStage: "INTERESTED" },
+    });
+  });
+
+  it("creates job with explicit stage", async () => {
+    const { createJob } = await import("@/services/jobs");
+
+    const mockCreated = { id: "job-2", stage: "APPLIED", createdAt: new Date() };
+    mockJobCreate.mockResolvedValue(mockCreated);
+    mockStageHistoryCreate.mockResolvedValue({});
+
+    await createJob({
+      userId: "user-1",
+      title: "Dev",
+      company: "Corp",
+      stage: "Applied",
+    });
+
+    expect(mockJobCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ stage: "APPLIED" }),
+      })
+    );
+    expect(mockStageHistoryCreate).toHaveBeenCalledWith({
+      data: { jobId: "job-2", fromStage: null, toStage: "APPLIED" },
+    });
+  });
+});
+
+describe("updateJob", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates job without creating stage history when stage unchanged", async () => {
+    const { updateJob } = await import("@/services/jobs");
+
+    mockJobFindFirst.mockResolvedValue({ id: "j1", userId: "u1", stage: "APPLIED" });
+    mockJobUpdate.mockResolvedValue({ id: "j1", stage: "APPLIED" });
+    mockStageHistoryCreate.mockResolvedValue({});
+
+    await updateJob("j1", "u1", { title: "Updated Title" });
+
+    expect(mockStageHistoryCreate).not.toHaveBeenCalled();
+    expect(mockActivityCreate).not.toHaveBeenCalled();
+  });
+
+  it("creates stage history and STAGE activity when stage changes", async () => {
+    const { updateJob } = await import("@/services/jobs");
+
+    mockJobFindFirst.mockResolvedValue({ id: "j1", userId: "u1", stage: "APPLIED" });
+    mockJobUpdate.mockResolvedValue({ id: "j1", stage: "INTERVIEW" });
+    mockStageHistoryCreate.mockResolvedValue({});
+    mockActivityCreate.mockResolvedValue({});
+
+    await updateJob("j1", "u1", { stage: "Interview" });
+
+    expect(mockStageHistoryCreate).toHaveBeenCalledWith({
+      data: { jobId: "j1", fromStage: "APPLIED", toStage: "INTERVIEW" },
+    });
+    expect(mockActivityCreate).toHaveBeenCalledWith({
+      data: {
+        jobId: "j1",
+        type: "STAGE",
+        title: "Stage changed: Applied → Interview",
+      },
+    });
+  });
+
+  it("returns null when job not found", async () => {
+    const { updateJob } = await import("@/services/jobs");
+
+    mockJobFindFirst.mockResolvedValue(null);
+
+    const result = await updateJob("missing", "u1", { title: "X" });
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Prepares the codebase for Sprint 2 demo by fixing bugs, filling seed data gaps, wiring up stage-to-timeline propagation, and adding missing test coverage.

## Changes

### Bug fixes
- **Duplicate tab rendering** in Job Detail page — Timeline, Interviews, and FollowUps sections were rendered twice (inside and outside tabpanel wrappers)
- **Duplicate `customNotes` spread** in `updateJob()` service function

### Feature: Stage transitions in timeline
- `updateJob()` now creates a `STAGE`-type `JobActivity` when a stage change is detected (e.g. "Stage changed: Applied → Interview"), so the timeline tab reflects stage transitions in real time

### Seed data (was only seeding Jobs — now seeds everything)
- **Profiles**: Full identity/contact/summary for both users
- **Experience**: 3 (User A), 2 (User B)
- **Education**: 2 per user
- **Skills**: 6 per user
- **Stage history**: Realistic transition chains per job stage
- **Activities**: STAGE events for transitions, INTERVIEW events for interview-stage jobs, FOLLOWUP items, NOTE entries
- **Documents**: 2 resume + 2 cover letter drafts linked to jobs per user
- **REJECTED stage**: Added a job in REJECTED stage (was missing)
- **Clean script**: Updated to wipe all related data types (not just jobs)

### Test coverage (149 → 178 tests)
- `tests/services/jobs.test.ts` — createJob, updateJob with stage-change + activity creation, null-not-found
- `tests/services/activities.test.ts` — verifyJobOwnership, getActivities, createActivity, updateActivity, deleteActivity
- `tests/api/jobs.test.ts` — GET/POST /api/jobs (auth, validation, error cases)
- `tests/api/jobs-activities.test.ts` — GET/POST /api/jobs/[id]/activities (auth, ownership, validation)

## Demo readiness checklist

| Demo requirement | Status |
|---|---|
| A1. Dashboard search/filter/sort + cards | ✅ Already working |
| A2. Job Detail workflow (overview/stage/deadline/contact) | ✅ Fixed duplicate rendering bug |
| A3. Interview/follow-up/timeline/stage workflow | ✅ Stage changes now appear in timeline |
| A4. Profile + AI doc flow | ⬜ Documents page still placeholder (out of scope) |
| B1. Workflow/data integrity proof | ✅ Stage change → history + activity + metrics |
| B2. CI + meaningful tests | ✅ 178 tests including negative paths |
| B3. Architecture Q&A | ✅ No code changes needed |

## Post-merge

Run `bun run db:clean` to wipe and re-seed with the expanded data before demo day.