### PR TITLE
fix: settings auth email, add-skill badge sizing, seed career preferences

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,15 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import { requireAuth } from "@/lib/requireAuth";
+
+export async function GET(request: NextRequest) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      return NextResponse.json({ email: user.email }, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/components/profile/skills-section.tsx
+++ b/src/components/profile/skills-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type DragEvent } from "react";
+import { type DragEvent, useState } from "react";
 import { SkillForm } from "@/components/profile/skill-form";
 import { ConfirmDeleteModal } from "@/components/ui/confirm-delete-modal";
 import { Modal } from "@/components/ui/modal";
@@ -50,9 +50,7 @@ export function SkillsSection({ skills, onUpdate }: SkillsSectionProps) {
 
   function handleSave(skill: Skill) {
     if (editingIndex !== null) {
-      const updated = skills.map((s, i) =>
-        i === editingIndex ? skill : s
-      );
+      const updated = skills.map((s, i) => (i === editingIndex ? skill : s));
       onUpdate(updated, "Skill updated");
     } else {
       onUpdate([...skills, skill], "Skill added");
@@ -113,68 +111,59 @@ export function SkillsSection({ skills, onUpdate }: SkillsSectionProps) {
         <ul className="flex flex-wrap gap-2">
           {skills.map((skill, index) => {
             const isDragging = draggedIndex === index;
-            const isDragTarget =
-              dragOverIndex === index && draggedIndex !== index;
+            const isDragTarget = dragOverIndex === index && draggedIndex !== index;
 
             return (
-                <li
-                  key={skill.id || index}
-                  draggable
-                  onDragStart={() => handleDragStart(index)}
-                  onDragOver={(e) => handleDragOver(e, index)}
-                  onDrop={() => handleDrop(index)}
-                  onDragEnd={handleDragEnd}
-                  className={[
-                    "group list-none rounded-lg border px-3 py-2 transition-colors",
-                    isDragging
-                      ? "border-indigo-500 bg-zinc-800 opacity-50"
-                      : isDragTarget
+              <li
+                key={skill.id || index}
+                draggable
+                onDragStart={() => handleDragStart(index)}
+                onDragOver={(e) => handleDragOver(e, index)}
+                onDrop={() => handleDrop(index)}
+                onDragEnd={handleDragEnd}
+                className={[
+                  "group list-none rounded-lg border px-3 py-2 transition-colors",
+                  isDragging
+                    ? "border-indigo-500 bg-zinc-800 opacity-50"
+                    : isDragTarget
                       ? "border-indigo-400 bg-zinc-800"
                       : "border-zinc-700 bg-zinc-800 hover:border-zinc-600",
-                  ].join(" ")}
-                >
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleEdit(index)}
-                      className="text-left"
-                    >
-                      <div className="text-sm text-zinc-200">
-                        {skill.name || (
-                          <span className="text-zinc-600">Unnamed</span>
-                        )}
+                ].join(" ")}
+              >
+                <div className="flex items-center gap-2">
+                  <button type="button" onClick={() => handleEdit(index)} className="text-left">
+                    <div className="text-sm text-zinc-200">
+                      {skill.name || <span className="text-zinc-600">Unnamed</span>}
+                    </div>
+
+                    {(skill.category || skill.proficiency) && (
+                      <div className="text-xs text-zinc-400">
+                        {[skill.category, skill.proficiency].filter(Boolean).join(" • ")}
                       </div>
+                    )}
+                  </button>
 
-                      {(skill.category || skill.proficiency) && (
-                        <div className="text-xs text-zinc-400">
-                          {[skill.category, skill.proficiency]
-                            .filter(Boolean)
-                            .join(" • ")}
-                        </div>
-                      )}
-                    </button>
+                  <span
+                    className="cursor-grab select-none px-1 text-zinc-500"
+                    title="Drag to reorder"
+                    aria-hidden="true"
+                  >
+                    ⋮⋮
+                  </span>
 
-                    <span
-                      className="cursor-grab select-none px-1 text-zinc-500"
-                      title="Drag to reorder"
-                      aria-hidden="true"
-                    >
-                      ⋮⋮
-                    </span>
-
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(index);
-                      }}
-                      className="text-zinc-600 hover:text-red-400"
-                      aria-label="Remove"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                </li>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(index);
+                    }}
+                    className="text-zinc-600 hover:text-red-400"
+                    aria-label="Remove"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </li>
             );
           })}
 
@@ -182,7 +171,7 @@ export function SkillsSection({ skills, onUpdate }: SkillsSectionProps) {
             <button
               type="button"
               onClick={handleAdd}
-              className="rounded-lg border border-dashed border-zinc-700 px-3 py-1.5 text-sm text-indigo-400 hover:border-zinc-600 hover:text-indigo-300"
+              className="rounded-lg border border-dashed border-zinc-700 px-3 py-2 text-sm text-indigo-400 hover:border-zinc-600 hover:text-indigo-300"
             >
               + Add skill
             </button>

--- a/src/components/settings/account-section.tsx
+++ b/src/components/settings/account-section.tsx
@@ -15,7 +15,7 @@ export function AccountSection() {
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    fetch("/api/profile")
+    fetch("/api/auth/me")
       .then((res) => res.json())
       .then((data) => {
         if (data.email) setEmail(data.email);

--- a/src/scripts/seed.ts
+++ b/src/scripts/seed.ts
@@ -146,6 +146,10 @@ const PROFILES: Record<
     location: string;
     headline: string;
     summary: string;
+    targetRoles: string[];
+    targetLocations: string[];
+    workModePreference: string | null;
+    salaryPreference: number | null;
     experiences: {
       type: "EMPLOYMENT" | "PROJECT";
       title: string;
@@ -176,6 +180,10 @@ const PROFILES: Record<
     headline: "Full Stack Software Engineer",
     summary:
       "Experienced software engineer with 4+ years building scalable web applications. Passionate about clean architecture, developer experience, and shipping products that solve real problems. Strong background in TypeScript, React, and Node.js.",
+    targetRoles: ["Full Stack Engineer", "Frontend Engineer", "Software Engineer"],
+    targetLocations: ["San Francisco, CA", "Remote", "New York, NY"],
+    workModePreference: "Remote",
+    salaryPreference: 150000,
     experiences: [
       {
         type: "EMPLOYMENT",
@@ -247,6 +255,10 @@ const PROFILES: Record<
     headline: "Senior Platform Engineer",
     summary:
       "Platform engineer with 6+ years of experience in distributed systems, cloud infrastructure, and developer tooling. Focused on building reliable, scalable backend systems. AWS certified with deep Kubernetes expertise.",
+    targetRoles: ["Staff Engineer", "Platform Engineer", "Backend Lead", "DevOps Engineer"],
+    targetLocations: ["Seattle, WA", "Remote", "Austin, TX"],
+    workModePreference: "Hybrid",
+    salaryPreference: 200000,
     experiences: [
       {
         type: "EMPLOYMENT",
@@ -351,6 +363,10 @@ async function seedProfile(userId: string, userLabel: string) {
       location: data.location,
       headline: data.headline,
       summary: data.summary,
+      targetRoles: data.targetRoles,
+      targetLocations: data.targetLocations,
+      workModePreference: data.workModePreference,
+      salaryPreference: data.salaryPreference,
     },
   });
 


### PR DESCRIPTION
## Summary
- Fix settings page showing profile contact email instead of Supabase Auth login email by adding `/api/auth/me` endpoint
- Fix "Add skill" button padding (`py-1.5` → `py-2`) to match skill badge sizing
- Add career preference seed data (`targetRoles`, `targetLocations`, `workModePreference`, `salaryPreference`) for both demo users