### PR TITLE
feat(ai): rate limit AI generation routes

### DIFF
--- a/src/app/api/ai/cover-letter/route.ts
+++ b/src/app/api/ai/cover-letter/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { ApiError, handleApiError } from "@/lib/api-error";
 import { withHttpLogging } from "@/lib/api-wrapper";
 import logger from "@/lib/logger";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { requireAuth } from "@/lib/requireAuth";
 import { validateBody } from "@/lib/validate-body";
 import { generateCoverLetterDraft } from "@/services/ai";
@@ -12,6 +13,13 @@ import { GenerateDocumentSchema } from "@/types/schemas";
 
 export async function POST(request: NextRequest) {
   return withHttpLogging(request, async () => {
+    const rateLimitResponse = await checkRateLimit(request, {
+      id: "api/ai/cover-letter",
+      limit: 10,
+      windowSecs: 60,
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
     try {
       const user = await requireAuth();
       const { jobId } = await validateBody(request, GenerateDocumentSchema);

--- a/src/app/api/ai/resume/route.ts
+++ b/src/app/api/ai/resume/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { ApiError, handleApiError } from "@/lib/api-error";
 import { withHttpLogging } from "@/lib/api-wrapper";
 import logger from "@/lib/logger";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { requireAuth } from "@/lib/requireAuth";
 import { validateBody } from "@/lib/validate-body";
 import { generateResumeDraft } from "@/services/ai";
@@ -12,6 +13,13 @@ import { GenerateDocumentSchema } from "@/types/schemas";
 
 export async function POST(request: NextRequest) {
   return withHttpLogging(request, async () => {
+    const rateLimitResponse = await checkRateLimit(request, {
+      id: "api/ai/resume",
+      limit: 10,
+      windowSecs: 60,
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
     try {
       const user = await requireAuth();
       const { jobId } = await validateBody(request, GenerateDocumentSchema);

--- a/src/app/api/ai/rewrite/route.ts
+++ b/src/app/api/ai/rewrite/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { ApiError, handleApiError } from "@/lib/api-error";
 import { withHttpLogging } from "@/lib/api-wrapper";
 import logger from "@/lib/logger";
+import { checkRateLimit } from "@/lib/rate-limit";
 import { requireAuth } from "@/lib/requireAuth";
 import { validateBody } from "@/lib/validate-body";
 import { rewriteContent } from "@/services/ai";
@@ -10,6 +11,13 @@ import { RewriteContentSchema } from "@/types/schemas";
 
 export async function POST(request: NextRequest) {
   return withHttpLogging(request, async () => {
+    const rateLimitResponse = await checkRateLimit(request, {
+      id: "api/ai/rewrite",
+      limit: 10,
+      windowSecs: 60,
+    });
+    if (rateLimitResponse) return rateLimitResponse;
+
     try {
       const user = await requireAuth();
       const { documentId, instruction } = await validateBody(request, RewriteContentSchema);

--- a/src/tests/api/ai-cover-letter.test.ts
+++ b/src/tests/api/ai-cover-letter.test.ts
@@ -1,0 +1,58 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequireAuth, mockGenerateCoverLetterDraft } = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockGenerateCoverLetterDraft: vi.fn(),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+  logError: vi.fn(),
+}));
+
+vi.mock("@/services/ai", () => ({
+  generateCoverLetterDraft: mockGenerateCoverLetterDraft,
+}));
+
+import { POST } from "@/app/api/ai/cover-letter/route";
+
+function makeRequest(): NextRequest {
+  return new Request("http://localhost/api/ai/cover-letter", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jobId: "job-1" }),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/ai/cover-letter rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 429 when rate limited without invoking auth or AI", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    const { NextResponse } = await import("next/server");
+    vi.mocked(checkRateLimit).mockResolvedValueOnce(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(429);
+    expect(mockRequireAuth).not.toHaveBeenCalled();
+    expect(mockGenerateCoverLetterDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/ai-resume.test.ts
+++ b/src/tests/api/ai-resume.test.ts
@@ -23,6 +23,10 @@ vi.mock("@/lib/api-wrapper", () => ({
   withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
 }));
 
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
 vi.mock("@/lib/requireAuth", () => ({
   requireAuth: mockRequireAuth,
 }));
@@ -140,5 +144,19 @@ describe("POST /api/ai/resume", () => {
 
     const res = await POST(makeRequest());
     expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited without invoking auth or AI", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    const { NextResponse } = await import("next/server");
+    vi.mocked(checkRateLimit).mockResolvedValueOnce(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(429);
+    expect(mockRequireAuth).not.toHaveBeenCalled();
+    expect(mockGenerateResumeDraft).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/ai-rewrite.test.ts
+++ b/src/tests/api/ai-rewrite.test.ts
@@ -1,0 +1,58 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequireAuth, mockRewriteContent } = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockRewriteContent: vi.fn(),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+  logError: vi.fn(),
+}));
+
+vi.mock("@/services/ai", () => ({
+  rewriteContent: mockRewriteContent,
+}));
+
+import { POST } from "@/app/api/ai/rewrite/route";
+
+function makeRequest(): NextRequest {
+  return new Request("http://localhost/api/ai/rewrite", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ documentId: "doc-1", instruction: "shorten" }),
+  }) as unknown as NextRequest;
+}
+
+describe("POST /api/ai/rewrite rate limiting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 429 when rate limited without invoking auth or AI", async () => {
+    const { checkRateLimit } = await import("@/lib/rate-limit");
+    const { NextResponse } = await import("next/server");
+    vi.mocked(checkRateLimit).mockResolvedValueOnce(
+      NextResponse.json({ error: "Too many requests" }, { status: 429 })
+    );
+
+    const res = await POST(makeRequest());
+
+    expect(res.status).toBe(429);
+    expect(mockRequireAuth).not.toHaveBeenCalled();
+    expect(mockRewriteContent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `checkRateLimit` (10 req/min per IP) to `/api/ai/resume`, `/api/ai/cover-letter`, and `/api/ai/rewrite`.
- Each route has its own limiter bucket (`api/ai/resume`, `api/ai/cover-letter`, `api/ai/rewrite`).
- Guards against an authenticated user spamming paid Gemini API calls.

## Why
Before this change, any signed-in user could hammer the Gemini endpoints without cost controls. The login/register/logout routes already use `checkRateLimit`; the AI routes were the only expensive endpoints left unbounded.

## Test plan
- [x] `bun run test` — full suite passes (187 tests), including 7 AI-route tests covering happy path + 429 short-circuit
- [x] `bun run type-check` — clean
- [x] `bun lint` — clean
- [ ] Manual: hit one of the AI endpoints 11 times in a minute, confirm the 11th returns `429` with `Retry-After`