### PR TITLE
fix(documents): make linkDocumentToJob idempotent

### DIFF
--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -227,8 +227,10 @@ export async function linkDocumentToJob(
 
   if (!job || !doc || !version) return null;
 
-  return prisma.jobDocumentLink.create({
-    data: { jobId, documentId, documentVersionId },
+  return prisma.jobDocumentLink.upsert({
+    where: { jobId_documentVersionId: { jobId, documentVersionId } },
+    create: { jobId, documentId, documentVersionId },
+    update: {},
   });
 }
 

--- a/src/tests/services/documents.test.ts
+++ b/src/tests/services/documents.test.ts
@@ -6,9 +6,11 @@ const mockDocFindFirst = vi.fn();
 const mockDocFindMany = vi.fn();
 const mockDocUpdate = vi.fn();
 const mockVersionCreate = vi.fn();
+const mockVersionFindFirst = vi.fn();
 const mockVersionFindMany = vi.fn();
 const mockJobFindFirst = vi.fn();
 const mockLinkCreate = vi.fn();
+const mockLinkUpsert = vi.fn();
 
 const tx = {
   document: { create: mockDocCreate, update: mockDocUpdate },
@@ -27,16 +29,18 @@ vi.mock("@/services/prisma", () => ({
     },
     documentVersion: {
       create: mockVersionCreate,
+      findFirst: mockVersionFindFirst,
       findMany: mockVersionFindMany,
     },
     job: { findFirst: mockJobFindFirst },
-    jobDocumentLink: { create: mockLinkCreate },
+    jobDocumentLink: { create: mockLinkCreate, upsert: mockLinkUpsert },
   },
 }));
 
 const {
   createDocument,
   getDocumentById,
+  linkDocumentToJob,
   softDeleteDocument,
   updateDocumentContent,
   toDocumentResponse,
@@ -189,5 +193,45 @@ describe("updateDocumentContent", () => {
     mockDocFindFirst.mockResolvedValue(null);
     const result = await updateDocumentContent("doc-999", USER_ID, "new content");
     expect(result).toBeNull();
+  });
+});
+
+describe("linkDocumentToJob", () => {
+  const baseLink = {
+    id: "link-1",
+    jobId: "job-1",
+    documentId: "doc-1",
+    documentVersionId: "ver-1",
+    linkedAt: now,
+  };
+
+  it("upserts idempotently so a duplicate link does not fail", async () => {
+    mockJobFindFirst.mockResolvedValue({ id: "job-1", userId: USER_ID });
+    mockDocFindFirst.mockResolvedValue(baseDoc);
+    mockVersionFindFirst.mockResolvedValue(baseVersion);
+    mockLinkUpsert.mockResolvedValue(baseLink);
+
+    const first = await linkDocumentToJob("job-1", "doc-1", "ver-1", USER_ID);
+    const second = await linkDocumentToJob("job-1", "doc-1", "ver-1", USER_ID);
+
+    expect(first).toEqual(baseLink);
+    expect(second).toEqual(baseLink);
+    expect(mockLinkUpsert).toHaveBeenCalledTimes(2);
+    expect(mockLinkUpsert).toHaveBeenCalledWith({
+      where: { jobId_documentVersionId: { jobId: "job-1", documentVersionId: "ver-1" } },
+      create: { jobId: "job-1", documentId: "doc-1", documentVersionId: "ver-1" },
+      update: {},
+    });
+  });
+
+  it("returns null when the job does not belong to the user", async () => {
+    mockJobFindFirst.mockResolvedValue(null);
+    mockDocFindFirst.mockResolvedValue(baseDoc);
+    mockVersionFindFirst.mockResolvedValue(baseVersion);
+
+    const result = await linkDocumentToJob("job-1", "doc-1", "ver-1", USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockLinkUpsert).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Switches `linkDocumentToJob` from `prisma.jobDocumentLink.create` to `upsert` keyed on the existing `@@unique([jobId, documentVersionId])` constraint.
- Adds tests covering duplicate-link idempotency and wrong-user 404.

## Why
The schema already prevents duplicate links (jobId + documentVersionId unique). But the service called `create` directly, so a repeat `POST /api/jobs/:id/documents` with the same document version hit the constraint and bubbled up a generic 500 via `handleApiError`. Now the second call is a no-op and returns the existing link, matching what the API consumer expects from an idempotent link operation. No migration needed.

## Test plan
- [x] `bun run test` — documents service tests (12 tests) pass, including new idempotency + wrong-user cases
- [x] `bun run type-check` — clean
- [x] `bun lint` — clean
- [ ] Manual: link the same document version to the same job twice via the UI, confirm the second attempt succeeds silently instead of erroring