### PR TITLE
feat(cover-letter): proper formatting with resume-style header and real date

### DIFF
--- a/src/app/(app)/documents/[id]/page.tsx
+++ b/src/app/(app)/documents/[id]/page.tsx
@@ -389,7 +389,7 @@ export default function DocumentDetailPage({ params }: { params: Promise<{ id: s
           ) : viewMode === "preview" ? (
             <div className="bg-zinc-950 rounded-md p-4 overflow-auto">
               {displayContent ? (
-                <div ref={previewRef} className="jakes-resume-preview">
+                <div ref={previewRef} className={`jakes-resume-preview${doc.type === "COVER_LETTER" ? " cover-letter-preview" : ""}`}>
                   <Markdown rehypePlugins={[rehypeRaw]}>{displayContent}</Markdown>
                 </div>
               ) : (

--- a/src/services/ai.ts
+++ b/src/services/ai.ts
@@ -179,8 +179,42 @@ export async function generateCoverLetterDraft(
   job: JobContext
 ): Promise<GenerateResult> {
   const name = [profile.firstName, profile.lastName].filter(Boolean).join(" ") || "Your Name";
+  const contactParts = [
+    profile.email,
+    profile.phone,
+    profile.location,
+  ].filter(Boolean);
 
-  const prompt = `You are an expert cover letter writer. Generate a professional, compelling cover letter in clean Markdown format.
+  const currentDate = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const COVER_LETTER_FORMAT_EXAMPLE = `# ${name}
+<div class="section headerInfo">
+
+${contactParts.join(" | ")}
+
+</div>
+
+${currentDate}
+
+${job.company}
+
+Dear Hiring Manager,
+
+[Opening paragraph — express enthusiasm for the role and company, mention the position title]
+
+[Middle paragraph(s) — connect experience and skills to the job requirements, highlight specific achievements with quantified impact]
+
+[Closing paragraph — restate interest, include a call to action, thank the reader]
+
+Sincerely,
+
+${name}`;
+
+  const prompt = `You are an expert cover letter writer. Generate a professional, compelling cover letter using the format below.
 
 TARGET JOB:
 Title: ${job.title}
@@ -189,19 +223,25 @@ Company: ${job.company}${job.description ? `\nDescription: ${job.description}` :
 CANDIDATE PROFILE:
 ${serializeProfile(profile)}
 
-FORMAT:
-- Start with the candidate's name, then contact info (email, phone, location) each on its own line
-- A blank line, then today's date placeholder: [Current Date]
-- A blank line, then the company name
-- Salutation (Dear Hiring Manager, or specific name if known)
+FORMAT EXAMPLE:
+${COVER_LETTER_FORMAT_EXAMPLE}
+
+FORMAT RULES:
+- Name must be "# " (h1 heading) — this renders large and centered
+- Contact info goes in a <div class="section headerInfo"> block right after the name, with email, phone, and location separated by " | "
+- Date is already set to today (${currentDate}) — use it exactly as shown
+- Company name on its own line after the date
+- Salutation: "Dear Hiring Manager," (or a specific name if known from the job description)
 - 3-4 body paragraphs that:
-  - Open with enthusiasm for the role and company
-  - Connect the candidate's experience and skills to the job requirements
-  - Highlight specific achievements and quantify impact when possible
-  - Close with a call to action and appreciation
-- Professional closing (Sincerely, followed by the candidate's name)
-- Use **bold** for key terms or company names sparingly
-- Output ONLY the cover letter, no preamble or explanation
+  - Open with genuine enthusiasm for the specific role and company
+  - Connect the candidate's experience directly to the job requirements
+  - Highlight specific achievements with quantified impact (numbers, percentages, user counts)
+  - Close with confidence, a call to action, and appreciation for the reader's time
+- Professional closing: "Sincerely," on its own line, then the candidate's name on the next line
+- Do NOT use bullet points or lists — cover letters are prose paragraphs only
+- Keep the letter to one page (250-400 words)
+- Use **bold** sparingly for key terms or company names
+- Output ONLY the cover letter content, no preamble, no explanation, no markdown code fences
 - Candidate's name to use: ${name}`;
 
   const content = await generateWithRetry(prompt);

--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -239,16 +239,17 @@ export async function getDocumentsForJob(jobId: string, userId: string) {
   const links = await prisma.jobDocumentLink.findMany({
     where: { jobId },
     include: {
-      document: true,
-      documentVersion: true,
+      document: {
+        include: { versions: { orderBy: { versionNumber: "desc" }, take: 1 } },
+      },
     },
     orderBy: { linkedAt: "desc" },
   });
 
   return links
-    .filter((l) => !l.document.isDeleted)
+    .filter((l) => !l.document.isDeleted && l.document.versions.length > 0)
     .map((l) => ({
-      ...toDocumentResponse(l.document, l.documentVersion),
+      ...toDocumentResponse(l.document, l.document.versions[0]),
       linkedAt: l.linkedAt.toISOString(),
     }));
 }

--- a/src/styles/jakes-resume.css
+++ b/src/styles/jakes-resume.css
@@ -121,3 +121,21 @@
 .jakes-resume-preview em {
   font-style: italic;
 }
+
+.cover-letter-preview p {
+  padding: 0;
+  margin: 0 0 8pt 0;
+  font-size: 10pt;
+  line-height: 1.5;
+}
+
+.cover-letter-preview .section.headerInfo {
+  margin-bottom: 16pt;
+}
+
+.cover-letter-preview .section.headerInfo p {
+  font-size: 9.5pt;
+  margin: 0;
+  padding: 0;
+  line-height: 1.35;
+}

--- a/src/tests/services/ai.test.ts
+++ b/src/tests/services/ai.test.ts
@@ -147,6 +147,19 @@ describe("generateCoverLetterDraft", () => {
     expect(call).toContain("Frontend Engineer");
   });
 
+  it("includes real date and headerInfo format in the prompt", async () => {
+    mockGenerateContent.mockResolvedValue({
+      response: { text: () => "Cover letter" },
+    });
+
+    await generateCoverLetterDraft(baseProfile, jobContext);
+
+    const call = mockGenerateContent.mock.calls[0][0];
+    expect(call).toContain("headerInfo");
+    expect(call).not.toContain("[Current Date]");
+    expect(call).toMatch(/\b(January|February|March|April|May|June|July|August|September|October|November|December) \d{1,2}, \d{4}\b/);
+  });
+
   it("throws on empty response", async () => {
     mockGenerateContent.mockResolvedValue({
       response: { text: () => "   " },


### PR DESCRIPTION
## Summary
- Rewrites cover letter AI prompt to use resume-style header (`# Name` + `headerInfo` div with pipe-separated contact info)
- Replaces `[Current Date]` placeholder with dynamically generated real date
- Adds `cover-letter-preview` CSS class with flush-left paragraphs and proper letter spacing
- Conditionally applies cover letter CSS when `doc.type === "COVER_LETTER"`
- Fixes stale version display on job detail page — `getDocumentsForJob()` now fetches latest version from document's `versions` relation instead of the stale `jobDocumentLink.documentVersion`

## Changes
- `src/services/ai.ts` — Rewrote `generateCoverLetterDraft()` with format example + rules
- `src/services/documents.ts` — `getDocumentsForJob()` fetches latest version directly
- `src/styles/jakes-resume.css` — Added `.cover-letter-preview` paragraph styles
- `src/app/(app)/documents/[id]/page.tsx` — Conditional CSS class for cover letters
- `src/tests/services/ai.test.ts` — Added test for real date and headerInfo in prompt

## Test plan
- [x] `bun run type-check` — clean
- [x] `bun lint` — clean
- [x] `bun run test` — 185 tests pass
- [x] `bun run build` — production build succeeds
- [ ] Manual: generate a cover letter and verify name is large/centered, contact info underneath, real date is shown
- [ ] Manual: re-generate a document from job detail page and verify version increments correctly