### PR TITLE
feat(timeline): date picker, edit/delete notes, inline time picker

### DIFF
--- a/src/app/(app)/dashboard/[jobId]/followups-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/followups-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
@@ -150,13 +151,13 @@ export function FollowUpsSection({ activities, jobId, onActivitiesChanged }: Pro
             onChange={handleChange}
             placeholder="e.g. Send thank-you email to recruiter"
           />
-          <Input
+          <DatePicker
             id="fu-due"
             label="Due date"
-            name="scheduledAt"
-            type="datetime-local"
             value={form.scheduledAt}
-            onChange={handleChange}
+            onChange={(v) => setForm((prev) => ({ ...prev, scheduledAt: v }))}
+            placeholder="Select date and time"
+            includeTime
           />
           <Textarea
             id="fu-notes"

--- a/src/app/(app)/dashboard/[jobId]/interviews-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/interviews-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
@@ -148,13 +149,13 @@ export function InterviewsSection({ activities, jobId, onActivitiesChanged }: Pr
                 ))}
               </select>
             </div>
-            <Input
+            <DatePicker
               id="scheduledAt"
               label="Date & time"
-              name="scheduledAt"
-              type="datetime-local"
               value={form.scheduledAt}
-              onChange={handleChange}
+              onChange={(v) => setForm((prev) => ({ ...prev, scheduledAt: v }))}
+              placeholder="Select date and time"
+              includeTime
             />
           </div>
           <Input

--- a/src/app/(app)/dashboard/[jobId]/timeline-section.tsx
+++ b/src/app/(app)/dashboard/[jobId]/timeline-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { DatePicker } from "@/components/ui/date-picker";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { showToast } from "@/components/ui/toast";
@@ -13,100 +14,153 @@ interface Props {
 }
 
 export function TimelineSection({ activities, jobId, onActivitiesChanged }: Props) {
-  const [addingNote, setAddingNote] = useState(false);
-  const [noteTitle, setNoteTitle] = useState("");
-  const [noteDesc, setNoteDesc] = useState("");
+  const [showForm, setShowForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
-  const sorted = [...activities].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+  const today = () => new Date().toISOString().split("T")[0];
+  const emptyForm = { title: "", date: today(), description: "" };
+  const [form, setForm] = useState(emptyForm);
 
-  async function handleAddNote() {
-    if (!noteTitle.trim()) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) {
+    setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  }
+
+  function startEdit(activity: JobActivity) {
+    setEditingId(activity.id);
+    setForm({
+      title: activity.title,
+      date: activity.scheduledAt ? activity.scheduledAt.slice(0, 10) : today(),
+      description: activity.description ?? "",
+    });
+    setShowForm(true);
+  }
+
+  function handleCancel() {
+    setShowForm(false);
+    setEditingId(null);
+    setForm({ ...emptyForm, date: today() });
+  }
+
+  async function handleSave() {
+    if (!form.title.trim()) {
       showToast("Note title is required", "error");
       return;
     }
     setSaving(true);
     try {
-      const res = await fetch(`/api/jobs/${jobId}/activities`, {
-        method: "POST",
+      const payload = {
+        type: "NOTE",
+        title: form.title.trim(),
+        description: form.description.trim() || undefined,
+        scheduledAt: new Date(`${form.date}T00:00:00`).toISOString(),
+      };
+      const url = editingId
+        ? `/api/jobs/${jobId}/activities/${editingId}`
+        : `/api/jobs/${jobId}/activities`;
+      const res = await fetch(url, {
+        method: editingId ? "PUT" : "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          type: "NOTE",
-          title: noteTitle.trim(),
-          description: noteDesc.trim() || undefined,
-        }),
+        body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error();
       await onActivitiesChanged();
-      setNoteTitle("");
-      setNoteDesc("");
-      setAddingNote(false);
-      showToast("Note added");
+      handleCancel();
+      showToast(editingId ? "Note updated" : "Note added");
     } catch {
-      showToast("Failed to add note", "error");
+      showToast("Failed to save note", "error");
     } finally {
       setSaving(false);
     }
   }
 
+  async function handleDelete(id: string) {
+    setDeleting(id);
+    try {
+      const res = await fetch(`/api/jobs/${jobId}/activities/${id}`, { method: "DELETE" });
+      if (!res.ok) throw new Error();
+      await onActivitiesChanged();
+      showToast("Note removed");
+    } catch {
+      showToast("Failed to remove note", "error");
+    } finally {
+      setDeleting(null);
+    }
+  }
+
+  const sorted = [...activities].sort((a, b) => {
+    const aDate = a.scheduledAt ?? a.createdAt;
+    const bDate = b.scheduledAt ?? b.createdAt;
+    return new Date(bDate).getTime() - new Date(aDate).getTime();
+  });
+
   return (
     <div className="bg-zinc-900 border border-zinc-700 rounded-lg p-6">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-base font-medium text-zinc-50">Timeline</h2>
-        <button
-          type="button"
-          onClick={() => setAddingNote(true)}
-          className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
-        >
-          + Add note
-        </button>
+        {!showForm && (
+          <button
+            type="button"
+            onClick={() => setShowForm(true)}
+            className="text-sm text-indigo-400 hover:text-indigo-300 transition-colors"
+          >
+            + Add note
+          </button>
+        )}
       </div>
 
-      {addingNote && (
+      {showForm && (
         <div className="mb-6 bg-zinc-800 border border-zinc-700 rounded-lg p-4 space-y-3">
+          <h3 className="text-sm font-medium text-zinc-200">
+            {editingId ? "Edit note" : "Add note"}
+          </h3>
           <Input
             id="note-title"
             label="Note title *"
+            name="title"
             type="text"
-            value={noteTitle}
-            onChange={(e) => setNoteTitle(e.target.value)}
+            value={form.title}
+            onChange={handleChange}
             placeholder="e.g. Heard back from recruiter"
+          />
+          <DatePicker
+            id="note-date"
+            label="Date"
+            value={form.date}
+            onChange={(v) => setForm((prev) => ({ ...prev, date: v }))}
+            placeholder="Select date"
           />
           <Textarea
             id="note-desc"
             label="Details"
-            value={noteDesc}
-            onChange={(e) => setNoteDesc(e.target.value)}
+            name="description"
+            value={form.description}
+            onChange={handleChange}
             placeholder="Optional details..."
             rows={3}
           />
           <div className="flex justify-end gap-2">
             <button
               type="button"
-              onClick={() => {
-                setAddingNote(false);
-                setNoteTitle("");
-                setNoteDesc("");
-              }}
+              onClick={handleCancel}
               className="bg-zinc-700 hover:bg-zinc-600 text-zinc-300 px-3 py-1.5 rounded-md text-sm"
             >
               Cancel
             </button>
             <button
               type="button"
-              onClick={handleAddNote}
+              onClick={handleSave}
               disabled={saving}
               className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-sm font-medium disabled:opacity-50"
             >
-              {saving ? "Saving..." : "Add note"}
+              {saving ? "Saving..." : editingId ? "Save changes" : "Add note"}
             </button>
           </div>
         </div>
       )}
 
-      {sorted.length === 0 ? (
+      {sorted.length === 0 && !showForm ? (
         <p className="text-sm text-zinc-500 text-center py-8">
           No activity yet. Events will appear here as you update this job.
         </p>
@@ -119,24 +173,43 @@ export function TimelineSection({ activities, jobId, onActivitiesChanged }: Prop
                   className={`w-1.5 h-1.5 rounded-full ${DOT_COLORS[activity.type] ?? "bg-zinc-500"}`}
                 />
               </span>
-              <div>
-                <p className="text-sm font-medium text-zinc-200">{activity.title}</p>
-                {activity.description && (
-                  <p className="text-xs text-zinc-400 mt-0.5">{activity.description}</p>
-                )}
-                <div className="flex items-center gap-2 mt-1">
-                  <span
-                    className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TYPE_BADGE[activity.type] ?? "bg-zinc-800 text-zinc-400"}`}
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-sm font-medium text-zinc-200">{activity.title}</p>
+                  {activity.description && (
+                    <p className="text-xs text-zinc-400 mt-0.5">{activity.description}</p>
+                  )}
+                  <div className="flex items-center gap-2 mt-1">
+                    <span
+                      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TYPE_BADGE[activity.type] ?? "bg-zinc-800 text-zinc-400"}`}
+                    >
+                      {activity.type.charAt(0) + activity.type.slice(1).toLowerCase()}
+                    </span>
+                    <span className="text-xs text-zinc-500">
+                      {new Date(activity.scheduledAt ?? activity.createdAt).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => startEdit(activity)}
+                    className="text-xs text-zinc-400 hover:text-zinc-50 px-2 py-1 rounded hover:bg-zinc-700 transition-colors"
                   >
-                    {activity.type.charAt(0) + activity.type.slice(1).toLowerCase()}
-                  </span>
-                  <span className="text-xs text-zinc-500">
-                    {new Date(activity.createdAt).toLocaleDateString("en-US", {
-                      month: "short",
-                      day: "numeric",
-                      year: "numeric",
-                    })}
-                  </span>
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(activity.id)}
+                    disabled={deleting === activity.id}
+                    className="text-xs text-red-400 hover:text-red-300 px-2 py-1 rounded hover:bg-zinc-700 transition-colors disabled:opacity-50"
+                  >
+                    {deleting === activity.id ? "..." : "Delete"}
+                  </button>
                 </div>
               </div>
             </li>

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -44,6 +44,23 @@ function Chevron({ orientation, ...props }: ChevronProps) {
   );
 }
 
+function time24ToParts(time24: string): { hour: string; minute: string; period: "AM" | "PM" } {
+  const [h, m] = time24.split(":").map(Number);
+  const period = h >= 12 ? "PM" : "AM";
+  const hour12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return { hour: String(hour12), minute: String(m).padStart(2, "0"), period };
+}
+
+function partsToTime24(hour: string, minute: string, period: "AM" | "PM"): string {
+  let h = parseInt(hour, 10);
+  if (Number.isNaN(h)) h = 12;
+  h = ((h % 12) + (period === "PM" ? 12 : 0)) % 24;
+  let m = parseInt(minute, 10);
+  if (Number.isNaN(m)) m = 0;
+  m = Math.max(0, Math.min(59, m));
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
 type DatePickerProps = {
   id: string;
   label?: string;
@@ -53,10 +70,10 @@ type DatePickerProps = {
   error?: string;
   required?: boolean;
   disabled?: boolean;
-  /** YYYY-MM-DD — earliest selectable date (inclusive) */
   minDate?: string;
-  /** YYYY-MM-DD — latest selectable date (inclusive) */
   maxDate?: string;
+  /** When true, includes a time picker. Value format becomes `YYYY-MM-DDTHH:mm`. */
+  includeTime?: boolean;
 };
 
 export function DatePicker({
@@ -70,10 +87,14 @@ export function DatePicker({
   disabled,
   minDate,
   maxDate,
+  includeTime,
 }: DatePickerProps) {
   const [open, setOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+
+  const dateValue = includeTime ? (value ? value.slice(0, 10) : "") : value;
+  const timeValue = includeTime && value ? value.slice(11) : "";
 
   useEffect(() => {
     setMounted(true);
@@ -101,26 +122,57 @@ export function DatePicker({
     return () => document.removeEventListener("mousedown", onClick);
   }, [id, open]);
 
-  const selected = value ? parse(value, "yyyy-MM-dd", new Date()) : undefined;
-  const displayValue = selected ? format(selected, "MMM d, yyyy") : "";
+  const selected = dateValue ? parse(dateValue, "yyyy-MM-dd", new Date()) : undefined;
   const minDateParsed = minDate ? parse(minDate, "yyyy-MM-dd", new Date()) : undefined;
   const maxDateParsed = maxDate ? parse(maxDate, "yyyy-MM-dd", new Date()) : undefined;
   const disabledMatchers: Matcher[] = [];
   if (minDateParsed) disabledMatchers.push({ before: minDateParsed });
   if (maxDateParsed) disabledMatchers.push({ after: maxDateParsed });
 
+  let displayValue = "";
+  if (selected) {
+    displayValue = format(selected, "MMM d, yyyy");
+    if (includeTime && timeValue) {
+      const parts = time24ToParts(timeValue);
+      displayValue += ` ${parts.hour}:${parts.minute} ${parts.period}`;
+    }
+  }
+
   function handleSelect(date: Date | undefined) {
-    if (date) {
-      onChange(format(date, "yyyy-MM-dd"));
+    if (!date) return;
+    const dateStr = format(date, "yyyy-MM-dd");
+    if (includeTime) {
+      const time = timeValue || "09:00";
+      onChange(`${dateStr}T${time}`);
+    } else {
+      onChange(dateStr);
       setOpen(false);
     }
+  }
+
+  function handleTimeChange(field: "hour" | "minute" | "period", val: string) {
+    const current = timeValue || "09:00";
+    const parts = time24ToParts(current);
+    const updated = { ...parts, [field]: field === "period" ? (val as "AM" | "PM") : val };
+    const dateStr = dateValue || format(new Date(), "yyyy-MM-dd");
+    onChange(`${dateStr}T${partsToTime24(updated.hour, updated.minute, updated.period)}`);
+  }
+
+  function handleTimeBlur() {
+    if (!timeValue) return;
+    const parts = time24ToParts(timeValue);
+    const h = parseInt(parts.hour, 10);
+    const m = parseInt(parts.minute, 10);
+    if (Number.isNaN(h) || Number.isNaN(m)) return;
+    const dateStr = dateValue || format(new Date(), "yyyy-MM-dd");
+    onChange(`${dateStr}T${partsToTime24(String(h), String(m), parts.period)}`);
   }
 
   function getPopoverStyle(): React.CSSProperties {
     if (!triggerRef.current) return { display: "none" };
     const rect = triggerRef.current.getBoundingClientRect();
     const spaceBelow = window.innerHeight - rect.bottom;
-    const approxHeight = 340;
+    const approxHeight = includeTime ? 410 : 340;
     const openAbove = spaceBelow < approxHeight;
     return {
       position: "fixed",
@@ -129,6 +181,8 @@ export function DatePicker({
       left: rect.left,
     };
   }
+
+  const timeParts = timeValue ? time24ToParts(timeValue) : { hour: "9", minute: "00", period: "AM" as const };
 
   return (
     <div>
@@ -197,6 +251,48 @@ export function DatePicker({
               endMonth={new Date(2035, 11)}
               defaultMonth={selected ?? minDateParsed ?? new Date()}
             />
+            {includeTime && (
+              <div className="mt-3 pt-3 border-t border-zinc-700 flex items-center gap-2">
+                <span className="text-[10px] font-medium text-zinc-500 shrink-0">Time</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={2}
+                  value={timeParts.hour}
+                  onChange={(e) => handleTimeChange("hour", e.target.value)}
+                  onBlur={handleTimeBlur}
+                  className="w-10 bg-zinc-800 border border-zinc-700 rounded-md px-1.5 py-1 text-xs text-zinc-50 text-center focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  aria-label="Hour"
+                />
+                <span className="text-xs text-zinc-500">:</span>
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={2}
+                  value={timeParts.minute}
+                  onChange={(e) => handleTimeChange("minute", e.target.value)}
+                  onBlur={handleTimeBlur}
+                  className="w-10 bg-zinc-800 border border-zinc-700 rounded-md px-1.5 py-1 text-xs text-zinc-50 text-center focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  aria-label="Minute"
+                />
+                <button
+                  type="button"
+                  onClick={() => handleTimeChange("period", timeParts.period === "AM" ? "PM" : "AM")}
+                  className="bg-zinc-800 border border-zinc-700 rounded-md px-2 py-1 text-xs text-zinc-50 hover:bg-zinc-700 transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  aria-label="Toggle AM/PM"
+                >
+                  {timeParts.period}
+                </button>
+                <div className="flex-1" />
+                <button
+                  type="button"
+                  onClick={() => setOpen(false)}
+                  className="bg-indigo-500 hover:bg-indigo-600 text-zinc-50 px-3 py-1.5 rounded-md text-xs font-medium"
+                >
+                  Done
+                </button>
+              </div>
+            )}
           </div>,
           document.body
         )}


### PR DESCRIPTION
## Summary

- Add date picker to timeline notes using the reusable `DatePicker` component (defaults to today, user can change)
- Add edit and delete functionality to timeline entries (matching the pattern from interviews/follow-ups)
- Add `includeTime` prop to `DatePicker` with inline hour/minute inputs and AM/PM toggle button (replacing native `datetime-local` dropdowns)
- Update interviews and follow-ups sections to use `DatePicker` with `includeTime` for consistent theming
- Timeline sorts and displays by `scheduledAt` when present, falls back to `createdAt`

## Files changed

- `src/components/ui/date-picker.tsx` — added `includeTime` prop with typeable hour/minute fields and AM/PM toggle
- `src/app/(app)/dashboard/[jobId]/timeline-section.tsx` — date picker, edit/delete per note
- `src/app/(app)/dashboard/[jobId]/interviews-section.tsx` — swapped `datetime-local` for themed `DatePicker`
- `src/app/(app)/dashboard/[jobId]/followups-section.tsx` — same swap