### PR TITLE
test(s3-021): expand unit test coverage for document logic

### DIFF
--- a/src/tests/api/documents-signed-url.test.ts
+++ b/src/tests/api/documents-signed-url.test.ts
@@ -1,0 +1,136 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequireAuth, mockCreateClient, mockCreateSignedUrl, mockDocFindFirst } = vi.hoisted(
+  () => ({
+    mockRequireAuth: vi.fn(),
+    mockCreateClient: vi.fn(),
+    mockCreateSignedUrl: vi.fn(),
+    mockDocFindFirst: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: { SUPABASE_DOCUMENTS_BUCKET: "documents" },
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: mockCreateClient,
+}));
+
+vi.mock("@/services/prisma", () => ({
+  prisma: {
+    document: { findFirst: mockDocFindFirst },
+  },
+}));
+
+import { GET } from "@/app/api/documents/[id]/signed-url/route";
+
+const USER_ID = "user-123";
+const now = new Date("2026-01-01T00:00:00.000Z");
+
+function makeRequest(): NextRequest {
+  return new Request("http://localhost/api/documents/doc-1/signed-url", {
+    method: "GET",
+  }) as unknown as NextRequest;
+}
+
+const context = { params: Promise.resolve({ id: "doc-1" }) };
+
+describe("GET /api/documents/[id]/signed-url", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ id: USER_ID });
+    mockCreateClient.mockResolvedValue({
+      storage: {
+        from: vi.fn().mockReturnValue({ createSignedUrl: mockCreateSignedUrl }),
+      },
+    });
+  });
+
+  it("returns 200 with signed URL when document is owned and has a file version", async () => {
+    mockDocFindFirst.mockResolvedValue({
+      id: "doc-1",
+      userId: USER_ID,
+      isDeleted: false,
+      versions: [{ id: "ver-1", fileUrl: `${USER_ID}/123.pdf`, versionNumber: 1, createdAt: now }],
+    });
+    mockCreateSignedUrl.mockResolvedValue({
+      data: { signedUrl: "https://example.com/signed" },
+      error: null,
+    });
+
+    const res = await GET(makeRequest(), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.url).toBe("https://example.com/signed");
+    expect(mockCreateSignedUrl).toHaveBeenCalledWith(`${USER_ID}/123.pdf`, 60 * 60);
+  });
+
+  it("scopes the lookup by userId so other users cannot retrieve the URL", async () => {
+    mockDocFindFirst.mockResolvedValue(null);
+
+    const res = await GET(makeRequest(), context);
+    expect(res.status).toBe(404);
+    expect(mockDocFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "doc-1", userId: USER_ID, isDeleted: false }),
+      })
+    );
+    expect(mockCreateSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the document has no version with a fileUrl", async () => {
+    mockDocFindFirst.mockResolvedValue({
+      id: "doc-1",
+      userId: USER_ID,
+      isDeleted: false,
+      versions: [],
+    });
+
+    const res = await GET(makeRequest(), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Not found");
+    expect(mockCreateSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await GET(makeRequest(), context);
+    expect(res.status).toBe(401);
+    expect(mockDocFindFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when supabase fails to generate the URL", async () => {
+    mockDocFindFirst.mockResolvedValue({
+      id: "doc-1",
+      userId: USER_ID,
+      isDeleted: false,
+      versions: [{ id: "ver-1", fileUrl: `${USER_ID}/x.pdf`, versionNumber: 1, createdAt: now }],
+    });
+    mockCreateSignedUrl.mockResolvedValue({ data: null, error: { message: "boom" } });
+
+    const res = await GET(makeRequest(), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("Could not generate signed URL");
+  });
+});

--- a/src/tests/api/documents-upload.test.ts
+++ b/src/tests/api/documents-upload.test.ts
@@ -1,0 +1,238 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockRequireAuth,
+  mockCreateDocument,
+  mockCreateClient,
+  mockStorageUpload,
+  mockVersionUpdate,
+  mockDocUpdate,
+} = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockCreateDocument: vi.fn(),
+  mockCreateClient: vi.fn(),
+  mockStorageUpload: vi.fn(),
+  mockVersionUpdate: vi.fn(),
+  mockDocUpdate: vi.fn(),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+  logError: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: { SUPABASE_DOCUMENTS_BUCKET: "documents" },
+}));
+
+vi.mock("@/lib/supabase-server", () => ({
+  createClient: mockCreateClient,
+}));
+
+vi.mock("@/services/documents", () => ({
+  createDocument: mockCreateDocument,
+}));
+
+vi.mock("@/services/prisma", () => ({
+  prisma: {
+    documentVersion: { update: mockVersionUpdate },
+    document: { update: mockDocUpdate },
+  },
+}));
+
+import { POST } from "@/app/api/documents/upload/route";
+
+const USER_ID = "user-123";
+const now = new Date("2026-01-01T00:00:00.000Z");
+const baseDoc = {
+  id: "doc-1",
+  userId: USER_ID,
+  type: "RESUME" as const,
+  name: "Resume.pdf",
+  status: "DRAFT" as const,
+  isDeleted: false,
+  deletedAt: null,
+  createdAt: now,
+  updatedAt: now,
+  category: null,
+};
+const baseVersion = {
+  id: "ver-1",
+  documentId: "doc-1",
+  versionNumber: 1,
+  content: null,
+  fileUrl: null,
+  createdAt: now,
+};
+
+// jsdom's Request cannot parse multipart bodies, so we stub formData() directly.
+function makeRequest(formData: StubForm): NextRequest {
+  return {
+    formData: async () => formData,
+  } as unknown as NextRequest;
+}
+
+// Stub File-like object: route only needs name, type, size, arrayBuffer().
+// Using a real File works under Node but not under Bun's vitest; this is portable.
+type StubFile = {
+  name: string;
+  type: string;
+  size: number;
+  arrayBuffer: () => Promise<ArrayBuffer>;
+};
+
+function pdfFile(opts: { size?: number; type?: string; name?: string } = {}): StubFile {
+  const size = opts.size ?? 1024;
+  return {
+    name: opts.name ?? "resume.pdf",
+    type: opts.type ?? "application/pdf",
+    size,
+    arrayBuffer: async () => new ArrayBuffer(size),
+  };
+}
+
+// Stub FormData with a get() that returns the values we set, mimicking the real API.
+type StubForm = { get: (key: string) => unknown };
+
+function buildForm(
+  overrides: { file?: StubFile | null; type?: string | null; name?: string | null } = {}
+): StubForm {
+  const file = overrides.file === undefined ? pdfFile() : overrides.file;
+  const type = overrides.type === null ? null : (overrides.type ?? "RESUME");
+  const name = overrides.name === null ? null : (overrides.name ?? "Resume.pdf");
+
+  return {
+    get: (key: string) => {
+      if (key === "file") return file ?? null;
+      if (key === "type") return type;
+      if (key === "name") return name;
+      return null;
+    },
+  };
+}
+
+describe("POST /api/documents/upload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({ id: USER_ID });
+    mockStorageUpload.mockResolvedValue({ error: null });
+    mockCreateClient.mockResolvedValue({
+      storage: {
+        from: vi.fn().mockReturnValue({ upload: mockStorageUpload }),
+      },
+    });
+    mockCreateDocument.mockResolvedValue({ doc: baseDoc, version: baseVersion });
+    mockVersionUpdate.mockResolvedValue({ ...baseVersion, fileUrl: "path" });
+    mockDocUpdate.mockResolvedValue({ ...baseDoc, status: "UPLOADED" });
+  });
+
+  it("returns 201 with UPLOADED document on valid PDF", async () => {
+    const res = await POST(makeRequest(buildForm()));
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.id).toBe("doc-1");
+    expect(body.status).toBe("UPLOADED");
+    expect(body.versionNumber).toBe(1);
+    expect(mockCreateDocument).toHaveBeenCalledWith(USER_ID, {
+      type: "RESUME",
+      name: "Resume.pdf",
+    });
+    expect(mockVersionUpdate).toHaveBeenCalledWith({
+      where: { id: "ver-1" },
+      data: { fileUrl: expect.stringContaining(`${USER_ID}/`) },
+    });
+    expect(mockDocUpdate).toHaveBeenCalledWith({
+      where: { id: "doc-1" },
+      data: { status: "UPLOADED" },
+    });
+  });
+
+  it("scopes the storage path under the authenticated user's id", async () => {
+    await POST(makeRequest(buildForm()));
+
+    const updateCall = mockVersionUpdate.mock.calls[0][0];
+    expect(updateCall.data.fileUrl).toMatch(new RegExp(`^${USER_ID}/\\d+\\.pdf$`));
+  });
+
+  it("returns 400 when file is missing", async () => {
+    const res = await POST(makeRequest(buildForm({ file: null })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("File is required");
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when type is missing", async () => {
+    const res = await POST(makeRequest(buildForm({ type: null })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Valid document type is required");
+  });
+
+  it("returns 400 when type is invalid", async () => {
+    const res = await POST(makeRequest(buildForm({ type: "BOGUS" })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Valid document type is required");
+  });
+
+  it("returns 400 when name is empty/whitespace", async () => {
+    const res = await POST(makeRequest(buildForm({ name: "   " })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Document name is required");
+  });
+
+  it("returns 400 when MIME type is not allowed", async () => {
+    const res = await POST(makeRequest(buildForm({ file: pdfFile({ type: "text/plain" }) })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/PDF/);
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when file exceeds 10MB", async () => {
+    const oversized = pdfFile({ size: 11 * 1024 * 1024 });
+    const res = await POST(makeRequest(buildForm({ file: oversized })));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/10MB/);
+    expect(mockStorageUpload).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await POST(makeRequest(buildForm()));
+    expect(res.status).toBe(401);
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 and does not create doc when storage upload fails", async () => {
+    mockStorageUpload.mockResolvedValue({ error: { message: "boom" } });
+
+    const res = await POST(makeRequest(buildForm()));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("File upload failed");
+    expect(mockCreateDocument).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/services/documents.test.ts
+++ b/src/tests/services/documents.test.ts
@@ -12,6 +12,7 @@ const mockJobFindFirst = vi.fn();
 const mockLinkCreate = vi.fn();
 const mockLinkUpsert = vi.fn();
 const mockLinkFindFirst = vi.fn();
+const mockLinkFindMany = vi.fn();
 
 const tx = {
   document: { create: mockDocCreate, update: mockDocUpdate },
@@ -34,14 +35,23 @@ vi.mock("@/services/prisma", () => ({
       findMany: mockVersionFindMany,
     },
     job: { findFirst: mockJobFindFirst },
-    jobDocumentLink: { create: mockLinkCreate, upsert: mockLinkUpsert, findFirst: mockLinkFindFirst },
+    jobDocumentLink: {
+      create: mockLinkCreate,
+      upsert: mockLinkUpsert,
+      findFirst: mockLinkFindFirst,
+      findMany: mockLinkFindMany,
+    },
   },
 }));
 
 const {
   createDocument,
+  createDocumentVersion,
   findDocumentByJob,
   getDocumentById,
+  getDocumentVersions,
+  getDocumentsByUserId,
+  getDocumentsForJob,
   linkDocumentToJob,
   softDeleteDocument,
   updateDocumentContent,
@@ -297,5 +307,283 @@ describe("cross-user access guards", () => {
         }),
       })
     );
+  });
+});
+
+describe("updateDocumentContent (versioning)", () => {
+  it("increments versionNumber by 1 over the latest existing version", async () => {
+    const v3 = { ...baseVersion, id: "ver-3", versionNumber: 3 };
+    mockDocFindFirst.mockResolvedValue({ ...baseDoc, versions: [v3] });
+    mockVersionCreate.mockResolvedValue({
+      ...baseVersion,
+      id: "ver-4",
+      versionNumber: 4,
+      content: "v4",
+    });
+    mockDocUpdate.mockResolvedValue(baseDoc);
+
+    const result = await updateDocumentContent("doc-1", USER_ID, "v4");
+
+    expect(mockVersionCreate).toHaveBeenCalledWith({
+      data: { documentId: "doc-1", versionNumber: 4, content: "v4" },
+    });
+    expect(result?.versionNumber).toBe(4);
+  });
+
+  it("starts at versionNumber 1 when no versions exist (defensive)", async () => {
+    mockDocFindFirst.mockResolvedValue({ ...baseDoc, versions: [] });
+    mockVersionCreate.mockResolvedValue({ ...baseVersion, content: "first" });
+    mockDocUpdate.mockResolvedValue(baseDoc);
+
+    await updateDocumentContent("doc-1", USER_ID, "first");
+
+    expect(mockVersionCreate).toHaveBeenCalledWith({
+      data: { documentId: "doc-1", versionNumber: 1, content: "first" },
+    });
+  });
+
+  it("filters out soft-deleted documents (isDeleted: false in where clause)", async () => {
+    mockDocFindFirst.mockResolvedValue(null);
+
+    await updateDocumentContent("doc-1", USER_ID, "x");
+
+    expect(mockDocFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isDeleted: false }),
+      })
+    );
+  });
+});
+
+describe("createDocumentVersion", () => {
+  const newVersion = { ...baseVersion, id: "ver-2", versionNumber: 2, content: "v2" };
+
+  it("creates the next version when document is owned by user", async () => {
+    mockDocFindFirst.mockResolvedValue({ ...baseDoc, versions: [baseVersion] });
+    mockVersionCreate.mockResolvedValue(newVersion);
+
+    const result = await createDocumentVersion("doc-1", USER_ID, "v2");
+
+    expect(result).toEqual({
+      id: "ver-2",
+      versionNumber: 2,
+      content: "v2",
+      createdAt: now.toISOString(),
+    });
+    expect(mockVersionCreate).toHaveBeenCalledWith({
+      data: { documentId: "doc-1", versionNumber: 2, content: "v2" },
+    });
+  });
+
+  it("returns null when document does not belong to user (no version created)", async () => {
+    mockDocFindFirst.mockResolvedValue(null);
+
+    const result = await createDocumentVersion("doc-1", "user-2", "tampered");
+
+    expect(result).toBeNull();
+    expect(mockVersionCreate).not.toHaveBeenCalled();
+  });
+
+  it("ignores soft-deleted documents", async () => {
+    mockDocFindFirst.mockResolvedValue(null);
+
+    await createDocumentVersion("doc-1", USER_ID, "x");
+
+    expect(mockDocFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ isDeleted: false }),
+      })
+    );
+  });
+});
+
+describe("getDocumentVersions", () => {
+  it("returns versions newest-first, mapped to DocumentVersionResponse", async () => {
+    mockDocFindFirst.mockResolvedValue(baseDoc);
+    mockVersionFindMany.mockResolvedValue([
+      { ...baseVersion, id: "ver-2", versionNumber: 2, content: "v2" },
+      { ...baseVersion, id: "ver-1", versionNumber: 1, content: "v1" },
+    ]);
+
+    const result = await getDocumentVersions("doc-1", USER_ID);
+
+    expect(result).toEqual([
+      { id: "ver-2", versionNumber: 2, content: "v2", createdAt: now.toISOString() },
+      { id: "ver-1", versionNumber: 1, content: "v1", createdAt: now.toISOString() },
+    ]);
+    expect(mockVersionFindMany).toHaveBeenCalledWith({
+      where: { documentId: "doc-1" },
+      orderBy: { versionNumber: "desc" },
+    });
+  });
+
+  it("returns null and does not fetch versions when document is not owned", async () => {
+    mockDocFindFirst.mockResolvedValue(null);
+
+    const result = await getDocumentVersions("doc-1", "user-2");
+
+    expect(result).toBeNull();
+    expect(mockVersionFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("getDocumentsByUserId", () => {
+  it("filters out documents with no versions", async () => {
+    const docWithVersion = { ...baseDoc, id: "doc-a", versions: [baseVersion] };
+    const docWithoutVersion = { ...baseDoc, id: "doc-b", versions: [] };
+    mockDocFindMany.mockResolvedValue([docWithVersion, docWithoutVersion]);
+
+    const result = await getDocumentsByUserId(USER_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("doc-a");
+  });
+
+  it("scopes by userId and excludes soft-deleted docs", async () => {
+    mockDocFindMany.mockResolvedValue([]);
+
+    await getDocumentsByUserId(USER_ID);
+
+    expect(mockDocFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER_ID, isDeleted: false },
+      })
+    );
+  });
+});
+
+describe("getDocumentsForJob", () => {
+  const job = { id: "job-1", userId: USER_ID };
+
+  it("returns null when the job does not belong to the user", async () => {
+    mockJobFindFirst.mockResolvedValue(null);
+
+    const result = await getDocumentsForJob("job-1", "user-2");
+
+    expect(result).toBeNull();
+    expect(mockLinkFindMany).not.toHaveBeenCalled();
+  });
+
+  it("filters out soft-deleted documents from links", async () => {
+    mockJobFindFirst.mockResolvedValue(job);
+    mockLinkFindMany.mockResolvedValue([
+      {
+        id: "link-1",
+        jobId: "job-1",
+        documentId: "doc-1",
+        documentVersionId: "ver-1",
+        linkedAt: now,
+        document: { ...baseDoc, isDeleted: false, versions: [baseVersion] },
+      },
+      {
+        id: "link-2",
+        jobId: "job-1",
+        documentId: "doc-2",
+        documentVersionId: "ver-2",
+        linkedAt: now,
+        document: {
+          ...baseDoc,
+          id: "doc-2",
+          isDeleted: true,
+          versions: [{ ...baseVersion, id: "ver-2", documentId: "doc-2" }],
+        },
+      },
+    ]);
+
+    const result = await getDocumentsForJob("job-1", USER_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0].id).toBe("doc-1");
+    expect(result?.[0].linkedAt).toBe(now.toISOString());
+  });
+
+  it("filters out documents with no versions", async () => {
+    mockJobFindFirst.mockResolvedValue(job);
+    mockLinkFindMany.mockResolvedValue([
+      {
+        id: "link-1",
+        jobId: "job-1",
+        documentId: "doc-1",
+        documentVersionId: "ver-1",
+        linkedAt: now,
+        document: { ...baseDoc, versions: [] },
+      },
+    ]);
+
+    const result = await getDocumentsForJob("job-1", USER_ID);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("findDocumentByJob (happy path)", () => {
+  it("returns the latest version of the linked document", async () => {
+    mockLinkFindFirst.mockResolvedValue({
+      id: "link-1",
+      jobId: "job-1",
+      documentId: "doc-1",
+      documentVersionId: "ver-2",
+      linkedAt: now,
+      document: {
+        ...baseDoc,
+        versions: [{ ...baseVersion, id: "ver-2", versionNumber: 2, content: "v2" }],
+      },
+    });
+
+    const result = await findDocumentByJob(USER_ID, "RESUME", "job-1");
+
+    expect(result?.doc.id).toBe("doc-1");
+    expect(result?.latestVersion.versionNumber).toBe(2);
+  });
+
+  it("returns null when the link exists but the document has no versions", async () => {
+    mockLinkFindFirst.mockResolvedValue({
+      id: "link-1",
+      jobId: "job-1",
+      documentId: "doc-1",
+      documentVersionId: "ver-1",
+      linkedAt: now,
+      document: { ...baseDoc, versions: [] },
+    });
+
+    const result = await findDocumentByJob(USER_ID, "RESUME", "job-1");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("linkDocumentToJob (cross-user ownership)", () => {
+  it("returns null when the document does not belong to the user", async () => {
+    mockJobFindFirst.mockResolvedValue({ id: "job-1", userId: USER_ID });
+    mockDocFindFirst.mockResolvedValue(null);
+    mockVersionFindFirst.mockResolvedValue(baseVersion);
+
+    const result = await linkDocumentToJob("job-1", "doc-1", "ver-1", USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockLinkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the version does not belong to the document", async () => {
+    mockJobFindFirst.mockResolvedValue({ id: "job-1", userId: USER_ID });
+    mockDocFindFirst.mockResolvedValue(baseDoc);
+    mockVersionFindFirst.mockResolvedValue(null);
+
+    const result = await linkDocumentToJob("job-1", "doc-1", "ver-99", USER_ID);
+
+    expect(result).toBeNull();
+    expect(mockLinkUpsert).not.toHaveBeenCalled();
+  });
+
+  it("scopes the version lookup to the documentId so cross-doc versions cannot link", async () => {
+    mockJobFindFirst.mockResolvedValue({ id: "job-1", userId: USER_ID });
+    mockDocFindFirst.mockResolvedValue(baseDoc);
+    mockVersionFindFirst.mockResolvedValue(null);
+
+    await linkDocumentToJob("job-1", "doc-1", "ver-from-other-doc", USER_ID);
+
+    expect(mockVersionFindFirst).toHaveBeenCalledWith({
+      where: { id: "ver-from-other-doc", documentId: "doc-1" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- 33 new tests covering document versioning, listing, ownership, upload, and signed-url download paths
- Service-level: `updateDocumentContent`, `createDocumentVersion`, `getDocumentVersions`, `getDocumentsByUserId`, `getDocumentsForJob`, `findDocumentByJob`, `linkDocumentToJob` cross-user/cross-doc guards
- API-level: `POST /api/documents/upload` (10 tests — auth, type/MIME/size validation, storage failures, user-scoped storage path) and `GET /api/documents/[id]/signed-url` (5 tests — auth, owner-scoped lookup, no-fileUrl 404, supabase failure)

Coverage matches the S3-021 outcome: "Document versioning, archive/restore, upload/download, and job-link ownership rules are unit-tested." Archive/restore service paths land in #158 and can have their tests added in that PR; this one closes the upload/download/versioning/ownership gap.

## Test plan
- [x] `bun run test` — 244/244 pass (was 211)
- [x] `bun run type-check` — clean
- [x] `bun lint` — clean
- [x] `bun run build` — clean

Closes #171