### PR TITLE
feat(s3-014): add velocity, stage conversion, and time-in-stage analytics

### DIFF
--- a/src/app/api/metrics/route.ts
+++ b/src/app/api/metrics/route.ts
@@ -2,14 +2,17 @@ import { type NextRequest, NextResponse } from "next/server";
 import { handleApiError } from "@/lib/api-error";
 import { withHttpLogging } from "@/lib/api-wrapper";
 import { requireAuth } from "@/lib/requireAuth";
-import { getDashboardMetrics } from "@/services/metrics";
+import { getAnalyticsBreakdown, getDashboardMetrics } from "@/services/metrics";
 
 export async function GET(request: NextRequest) {
   return withHttpLogging(request, async () => {
     try {
       const user = await requireAuth();
-      const metrics = await getDashboardMetrics(user.id);
-      return NextResponse.json(metrics, { status: 200 });
+      const [metrics, analytics] = await Promise.all([
+        getDashboardMetrics(user.id),
+        getAnalyticsBreakdown(user.id),
+      ]);
+      return NextResponse.json({ ...metrics, analytics }, { status: 200 });
     } catch (err) {
       return handleApiError(err);
     }

--- a/src/components/dashboard/metrics-panel.tsx
+++ b/src/components/dashboard/metrics-panel.tsx
@@ -4,7 +4,9 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import { STAGE_STYLES } from "@/constants/job-stages";
 import type { JobStage } from "@/types/job";
-import type { DashboardMetrics } from "@/services/metrics";
+import type { AnalyticsBreakdown, DashboardMetrics } from "@/services/metrics";
+
+type MetricsResponse = DashboardMetrics & { analytics?: AnalyticsBreakdown };
 
 const PIPELINE_ORDER: JobStage[] = [
   "Interested",
@@ -20,7 +22,7 @@ const STORAGE_KEY = "dartly:metrics-expanded";
 
 export function MetricsPanel({ refreshKey }: { refreshKey: number }) {
   const router = useRouter();
-  const [metrics, setMetrics] = useState<DashboardMetrics | null>(null);
+  const [metrics, setMetrics] = useState<MetricsResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState<boolean | null>(null);
 
@@ -170,7 +172,9 @@ export function MetricsPanel({ refreshKey }: { refreshKey: number }) {
       )}
 
       {totalForBar > 0 && (
-        <div className={`rounded-lg border border-zinc-700 bg-zinc-800/50 p-4 ${expanded ? "mt-3" : "mt-2"}`}>
+        <div
+          className={`rounded-lg border border-zinc-700 bg-zinc-800/50 p-4 ${expanded ? "mt-3" : "mt-2"}`}
+        >
           <div className="flex h-3 overflow-hidden rounded-full bg-zinc-900">
             {PIPELINE_ORDER.map((stage) => {
               const count = metrics.stageCounts[stage] ?? 0;
@@ -203,6 +207,127 @@ export function MetricsPanel({ refreshKey }: { refreshKey: number }) {
           </div>
         </div>
       )}
+
+      {expanded && metrics.analytics && <AnalyticsSection analytics={metrics.analytics} />}
+    </div>
+  );
+}
+
+function AnalyticsSection({ analytics }: { analytics: AnalyticsBreakdown }) {
+  const { velocity, funnel, timeInStage } = analytics;
+  const maxWeekly = Math.max(1, ...velocity.weeklyCounts);
+  const maxFunnel = Math.max(1, funnel.reachedInterested);
+
+  const changeArrow = velocity.changePercent > 0 ? "▲" : velocity.changePercent < 0 ? "▼" : "•";
+  const changeColor =
+    velocity.changePercent > 0
+      ? "text-green-400"
+      : velocity.changePercent < 0
+        ? "text-red-400"
+        : "text-zinc-500";
+  const velocityInsight =
+    velocity.last30Days === 0
+      ? "No applications in the last 30 days"
+      : velocity.prior30Days === 0
+        ? `${velocity.last30Days} applications in the last 30 days`
+        : `${changeArrow} ${Math.abs(velocity.changePercent)}% vs prior 30 days`;
+
+  const funnelRows: { label: JobStage; count: number; rate: number | null }[] = [
+    { label: "Interested", count: funnel.reachedInterested, rate: null },
+    { label: "Applied", count: funnel.reachedApplied, rate: funnel.appliedRate },
+    { label: "Interview", count: funnel.reachedInterview, rate: funnel.interviewRate },
+    { label: "Offer", count: funnel.reachedOffer, rate: funnel.offerRate },
+  ];
+
+  const stagesWithTime = (["INTERESTED", "APPLIED", "INTERVIEW"] as const).filter(
+    (s) => typeof timeInStage[s] === "number"
+  );
+
+  return (
+    <div className="mt-3 grid grid-cols-1 gap-3 lg:grid-cols-3">
+      {/* Velocity */}
+      <div className="rounded-lg border border-zinc-700 border-l-[3px] border-l-blue-400 bg-zinc-800/50 p-4">
+        <div className="flex items-baseline justify-between">
+          <p className="text-xs text-zinc-400">Velocity (last 30 days)</p>
+          <p className={`text-xs font-medium ${changeColor}`}>{velocityInsight}</p>
+        </div>
+        <p className="mt-1.5 text-xl font-semibold text-zinc-50">
+          {velocity.last30Days}
+          <span className="ml-1.5 text-xs font-normal text-zinc-500">applications</span>
+        </p>
+        <div className="mt-3 flex h-10 items-end gap-1">
+          {velocity.weeklyCounts.map((count, i) => {
+            const height = (count / maxWeekly) * 100;
+            const weekStart = velocity.weekStartIsos[i];
+            return (
+              <div
+                key={weekStart || i}
+                className="flex-1 rounded-sm bg-blue-500/30 transition-all hover:bg-blue-500/60"
+                style={{ height: `${Math.max(height, 4)}%` }}
+                title={`${count} application${count === 1 ? "" : "s"} this week`}
+              />
+            );
+          })}
+        </div>
+        <div className="mt-1 flex justify-between text-[10px] text-zinc-500">
+          <span>4w ago</span>
+          <span>this week</span>
+        </div>
+      </div>
+
+      {/* Funnel */}
+      <div className="rounded-lg border border-zinc-700 border-l-[3px] border-l-yellow-400 bg-zinc-800/50 p-4">
+        <p className="text-xs text-zinc-400">Stage Conversion</p>
+        <div className="mt-3 space-y-2">
+          {funnelRows.map(({ label, count, rate }) => {
+            const width = (count / maxFunnel) * 100;
+            return (
+              <div key={label}>
+                <div className="flex items-center justify-between text-xs">
+                  <span className="text-zinc-300">{label}</span>
+                  <span className="text-zinc-400">
+                    {count}
+                    {rate !== null && <span className="ml-1.5 text-zinc-500">({rate}%)</span>}
+                  </span>
+                </div>
+                <div className="mt-0.5 h-1.5 rounded-full bg-zinc-900">
+                  <div
+                    className={`h-full rounded-full ${STAGE_STYLES[label].dot} transition-all`}
+                    style={{ width: `${width}%`, minWidth: count > 0 ? "4px" : "0" }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Time in stage */}
+      <div className="rounded-lg border border-zinc-700 border-l-[3px] border-l-zinc-400 bg-zinc-800/50 p-4">
+        <p className="text-xs text-zinc-400">Avg. time in stage</p>
+        {stagesWithTime.length === 0 ? (
+          <p className="mt-3 text-xs text-zinc-500">
+            Move jobs between stages to see how long each stage takes.
+          </p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {stagesWithTime.map((s) => {
+              const days = timeInStage[s] ?? 0;
+              const label =
+                s === "INTERESTED" ? "Interested" : s === "APPLIED" ? "Applied" : "Interview";
+              return (
+                <li key={s} className="flex items-baseline justify-between text-sm">
+                  <span className="text-zinc-300">{label}</span>
+                  <span className="text-zinc-50">
+                    {days}{" "}
+                    <span className="text-xs text-zinc-500">{days === 1 ? "day" : "days"}</span>
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/services/metrics.ts
+++ b/src/services/metrics.ts
@@ -12,6 +12,38 @@ export type DashboardMetrics = {
   offerCount: number;
 };
 
+export type VelocityMetrics = {
+  last30Days: number;
+  prior30Days: number;
+  changePercent: number;
+  weeklyCounts: number[]; // length 4, oldest → newest week
+  weekStartIsos: string[]; // length 4, ISO date strings of each bucket start
+};
+
+export type FunnelMetrics = {
+  reachedInterested: number;
+  reachedApplied: number;
+  reachedInterview: number;
+  reachedOffer: number;
+  appliedRate: number;
+  interviewRate: number;
+  offerRate: number;
+};
+
+export type AnalyticsBreakdown = {
+  velocity: VelocityMetrics;
+  funnel: FunnelMetrics;
+  timeInStage: Partial<Record<string, number>>;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FUNNEL_RANK: Record<string, number> = {
+  INTERESTED: 0,
+  APPLIED: 1,
+  INTERVIEW: 2,
+  OFFER: 3,
+};
+
 export async function getDashboardMetrics(userId: string): Promise<DashboardMetrics> {
   const jobs = await prisma.job.findMany({ where: { userId } });
 
@@ -34,9 +66,7 @@ export async function getDashboardMetrics(userId: string): Promise<DashboardMetr
   const responseRate =
     nonInterestedCount > 0 ? Math.round((responseCount / nonInterestedCount) * 100) : 0;
 
-  const interviewCount = jobs.filter(
-    (j) => j.stage === "INTERVIEW" || j.stage === "OFFER"
-  ).length;
+  const interviewCount = jobs.filter((j) => j.stage === "INTERVIEW" || j.stage === "OFFER").length;
   const interviewRate =
     nonInterestedCount > 0 ? Math.round((interviewCount / nonInterestedCount) * 100) : 0;
 
@@ -60,4 +90,121 @@ export async function getDashboardMetrics(userId: string): Promise<DashboardMetr
     ghostRate,
     offerCount,
   };
+}
+
+export async function getAnalyticsBreakdown(userId: string): Promise<AnalyticsBreakdown> {
+  const jobs = await prisma.job.findMany({ where: { userId } });
+  const jobIds = jobs.map((j) => j.id);
+  const history =
+    jobIds.length > 0
+      ? await prisma.jobStageHistory.findMany({ where: { jobId: { in: jobIds } } })
+      : [];
+
+  return {
+    velocity: computeVelocity(jobs),
+    funnel: computeFunnel(jobs, history),
+    timeInStage: computeTimeInStage(history),
+  };
+}
+
+function computeVelocity(jobs: { applicationDate: Date | null }[]): VelocityMetrics {
+  const now = Date.now();
+  const cutoff30 = now - 30 * DAY_MS;
+  const cutoff60 = now - 60 * DAY_MS;
+
+  let last30 = 0;
+  let prior30 = 0;
+  for (const job of jobs) {
+    if (!job.applicationDate) continue;
+    const t = job.applicationDate.getTime();
+    if (t >= cutoff30 && t <= now) last30 += 1;
+    else if (t >= cutoff60 && t < cutoff30) prior30 += 1;
+  }
+  const changePercent = prior30 > 0 ? Math.round(((last30 - prior30) / prior30) * 100) : 0;
+
+  // 4 weekly buckets, oldest → newest. Each bucket is 7 days.
+  const weeklyCounts = [0, 0, 0, 0];
+  const weekStartIsos: string[] = [];
+  for (let i = 0; i < 4; i++) {
+    // i=0 → oldest (28-21d ago), i=3 → newest (7-0d ago)
+    const start = now - (4 - i) * 7 * DAY_MS;
+    weekStartIsos.push(new Date(start).toISOString());
+  }
+  for (const job of jobs) {
+    if (!job.applicationDate) continue;
+    const t = job.applicationDate.getTime();
+    const daysAgo = Math.floor((now - t) / DAY_MS);
+    if (daysAgo < 0 || daysAgo >= 28) continue;
+    const bucket = 3 - Math.floor(daysAgo / 7);
+    weeklyCounts[bucket] += 1;
+  }
+
+  return { last30Days: last30, prior30Days: prior30, changePercent, weeklyCounts, weekStartIsos };
+}
+
+function computeFunnel(
+  jobs: { id: string; stage: string }[],
+  history: { jobId: string; toStage: string }[]
+): FunnelMetrics {
+  const maxRankByJob = new Map<string, number>();
+  for (const job of jobs) {
+    const currentRank = FUNNEL_RANK[job.stage] ?? -1;
+    maxRankByJob.set(job.id, currentRank);
+  }
+  for (const h of history) {
+    const rank = FUNNEL_RANK[h.toStage];
+    if (rank === undefined) continue; // terminal stage, skip
+    const prev = maxRankByJob.get(h.jobId) ?? -1;
+    if (rank > prev) maxRankByJob.set(h.jobId, rank);
+  }
+
+  const reachedInterested = jobs.length;
+  let reachedApplied = 0;
+  let reachedInterview = 0;
+  let reachedOffer = 0;
+  for (const rank of maxRankByJob.values()) {
+    if (rank >= 1) reachedApplied += 1;
+    if (rank >= 2) reachedInterview += 1;
+    if (rank >= 3) reachedOffer += 1;
+  }
+
+  return {
+    reachedInterested,
+    reachedApplied,
+    reachedInterview,
+    reachedOffer,
+    appliedRate: reachedInterested > 0 ? Math.round((reachedApplied / reachedInterested) * 100) : 0,
+    interviewRate: reachedApplied > 0 ? Math.round((reachedInterview / reachedApplied) * 100) : 0,
+    offerRate: reachedInterview > 0 ? Math.round((reachedOffer / reachedInterview) * 100) : 0,
+  };
+}
+
+function computeTimeInStage(
+  history: { jobId: string; toStage: string; changedAt: Date }[]
+): Partial<Record<string, number>> {
+  const byJob = new Map<string, { toStage: string; changedAt: Date }[]>();
+  for (const h of history) {
+    const arr = byJob.get(h.jobId) ?? [];
+    arr.push(h);
+    byJob.set(h.jobId, arr);
+  }
+
+  const sums: Record<string, { totalDays: number; count: number }> = {};
+  for (const events of byJob.values()) {
+    events.sort((a, b) => a.changedAt.getTime() - b.changedAt.getTime());
+    for (let i = 0; i < events.length - 1; i++) {
+      const stage = events[i].toStage;
+      const days = (events[i + 1].changedAt.getTime() - events[i].changedAt.getTime()) / DAY_MS;
+      const bucket = sums[stage] ?? { totalDays: 0, count: 0 };
+      bucket.totalDays += days;
+      bucket.count += 1;
+      sums[stage] = bucket;
+    }
+  }
+
+  const result: Partial<Record<string, number>> = {};
+  for (const [stage, { totalDays, count }] of Object.entries(sums)) {
+    result[stage] = Math.round(totalDays / count);
+  }
+  return result;
 }

--- a/src/tests/api/metrics.test.ts
+++ b/src/tests/api/metrics.test.ts
@@ -1,9 +1,10 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockRequireAuth, mockGetDashboardMetrics } = vi.hoisted(() => ({
+const { mockRequireAuth, mockGetDashboardMetrics, mockGetAnalyticsBreakdown } = vi.hoisted(() => ({
   mockRequireAuth: vi.fn(),
   mockGetDashboardMetrics: vi.fn(),
+  mockGetAnalyticsBreakdown: vi.fn(),
 }));
 
 vi.mock("@/lib/api-wrapper", () => ({
@@ -20,6 +21,7 @@ vi.mock("@/lib/logger", () => ({
 
 vi.mock("@/services/metrics", () => ({
   getDashboardMetrics: mockGetDashboardMetrics,
+  getAnalyticsBreakdown: mockGetAnalyticsBreakdown,
 }));
 
 import { GET } from "@/app/api/metrics/route";
@@ -42,21 +44,43 @@ function makeRequest(): NextRequest {
   }) as unknown as NextRequest;
 }
 
+const mockAnalytics = {
+  velocity: {
+    last30Days: 4,
+    prior30Days: 2,
+    changePercent: 100,
+    weeklyCounts: [0, 1, 1, 2],
+    weekStartIsos: ["", "", "", ""],
+  },
+  funnel: {
+    reachedInterested: 6,
+    reachedApplied: 4,
+    reachedInterview: 2,
+    reachedOffer: 1,
+    appliedRate: 67,
+    interviewRate: 50,
+    offerRate: 50,
+  },
+  timeInStage: { APPLIED: 8 },
+};
+
 describe("GET /api/metrics", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireAuth.mockResolvedValue(mockUser);
+    mockGetAnalyticsBreakdown.mockResolvedValue(mockAnalytics);
   });
 
-  it("returns 200 with metrics", async () => {
+  it("returns 200 with metrics merged with analytics", async () => {
     mockGetDashboardMetrics.mockResolvedValue(mockMetrics);
 
     const res = await GET(makeRequest());
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual(mockMetrics);
+    expect(body).toEqual({ ...mockMetrics, analytics: mockAnalytics });
     expect(mockGetDashboardMetrics).toHaveBeenCalledWith("user-123");
+    expect(mockGetAnalyticsBreakdown).toHaveBeenCalledWith("user-123");
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -86,5 +110,6 @@ describe("GET /api/metrics", () => {
     expect(body.totalJobs).toBe(0);
     expect(body.ghostRate).toBe(0);
     expect(body.offerCount).toBe(0);
+    expect(body.analytics).toBeDefined();
   });
 });

--- a/src/tests/services/metrics.test.ts
+++ b/src/tests/services/metrics.test.ts
@@ -1,19 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockJobFindMany = vi.fn();
+const mockStageHistoryFindMany = vi.fn();
 
 vi.mock("@/services/prisma", () => ({
   prisma: {
     job: { findMany: mockJobFindMany },
+    jobStageHistory: { findMany: mockStageHistoryFindMany },
   },
 }));
 
-const { getDashboardMetrics } = await import("@/services/metrics");
+const { getDashboardMetrics, getAnalyticsBreakdown } = await import("@/services/metrics");
 
 const USER_ID = "user-1";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockStageHistoryFindMany.mockResolvedValue([]);
 });
 
 describe("getDashboardMetrics", () => {
@@ -137,5 +140,218 @@ describe("getDashboardMetrics", () => {
     expect(metrics.interviewRate).toBe(0);
     expect(metrics.rejectionRate).toBe(0);
     expect(metrics.ghostRate).toBe(0);
+  });
+});
+
+describe("getAnalyticsBreakdown — velocity", () => {
+  // Pin "now" so tests are deterministic regardless of run time.
+  const NOW = new Date("2026-04-27T12:00:00.000Z");
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  it("returns zero velocity when user has no jobs", async () => {
+    mockJobFindMany.mockResolvedValue([]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.velocity.last30Days).toBe(0);
+    expect(a.velocity.prior30Days).toBe(0);
+    expect(a.velocity.changePercent).toBe(0);
+    expect(a.velocity.weeklyCounts).toEqual([0, 0, 0, 0]);
+    expect(a.velocity.weekStartIsos).toHaveLength(4);
+  });
+
+  it("counts applications inside the last 30 days only", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "APPLIED", applicationDate: new Date("2026-04-26T00:00:00Z") }, // 1d ago
+      { id: "j2", stage: "APPLIED", applicationDate: new Date("2026-04-15T00:00:00Z") }, // 12d ago
+      { id: "j3", stage: "APPLIED", applicationDate: new Date("2026-03-20T00:00:00Z") }, // 38d ago — prior window
+      { id: "j4", stage: "INTERESTED", applicationDate: null }, // never applied
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.velocity.last30Days).toBe(2);
+    expect(a.velocity.prior30Days).toBe(1);
+  });
+
+  it("computes changePercent vs prior 30 days (rounded to int)", async () => {
+    mockJobFindMany.mockResolvedValue([
+      // 4 in last 30 days
+      { id: "a", stage: "APPLIED", applicationDate: new Date("2026-04-26") },
+      { id: "b", stage: "APPLIED", applicationDate: new Date("2026-04-22") },
+      { id: "c", stage: "APPLIED", applicationDate: new Date("2026-04-18") },
+      { id: "d", stage: "APPLIED", applicationDate: new Date("2026-04-12") },
+      // 2 in prior 30 days (between 30 and 60 days ago)
+      { id: "e", stage: "APPLIED", applicationDate: new Date("2026-03-20") },
+      { id: "f", stage: "APPLIED", applicationDate: new Date("2026-03-10") },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.velocity.last30Days).toBe(4);
+    expect(a.velocity.prior30Days).toBe(2);
+    expect(a.velocity.changePercent).toBe(100); // (4-2)/2 * 100
+  });
+
+  it("returns 0 changePercent when prior 30 days had zero applications (avoid div-by-zero)", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "APPLIED", applicationDate: new Date("2026-04-26") },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.velocity.prior30Days).toBe(0);
+    expect(a.velocity.changePercent).toBe(0);
+  });
+
+  it("buckets applications into 4 weekly windows (oldest first)", async () => {
+    mockJobFindMany.mockResolvedValue([
+      // last 7d (week 4): 2
+      { id: "a", stage: "APPLIED", applicationDate: new Date("2026-04-26") }, // 1d
+      { id: "b", stage: "APPLIED", applicationDate: new Date("2026-04-22") }, // 5d
+      // 7-14d (week 3): 1
+      { id: "c", stage: "APPLIED", applicationDate: new Date("2026-04-15") }, // 12d
+      // 14-21d (week 2): 1
+      { id: "d", stage: "APPLIED", applicationDate: new Date("2026-04-08") }, // 19d
+      // 21-28d (week 1): 0
+      // outside 28d: ignored from buckets
+      { id: "e", stage: "APPLIED", applicationDate: new Date("2026-03-20") },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.velocity.weeklyCounts).toEqual([0, 1, 1, 2]);
+  });
+});
+
+describe("getAnalyticsBreakdown — funnel", () => {
+  it("returns zeros when there are no jobs", async () => {
+    mockJobFindMany.mockResolvedValue([]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.funnel.reachedInterested).toBe(0);
+    expect(a.funnel.reachedApplied).toBe(0);
+    expect(a.funnel.reachedInterview).toBe(0);
+    expect(a.funnel.reachedOffer).toBe(0);
+    expect(a.funnel.appliedRate).toBe(0);
+    expect(a.funnel.interviewRate).toBe(0);
+    expect(a.funnel.offerRate).toBe(0);
+  });
+
+  it("counts every job toward 'reachedInterested'", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "INTERESTED" },
+      { id: "j2", stage: "APPLIED" },
+      { id: "j3", stage: "REJECTED" },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.funnel.reachedInterested).toBe(3);
+  });
+
+  it("uses current stage when no history is recorded", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "INTERESTED" },
+      { id: "j2", stage: "APPLIED" },
+      { id: "j3", stage: "INTERVIEW" },
+      { id: "j4", stage: "OFFER" },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.funnel.reachedApplied).toBe(3); // j2,j3,j4
+    expect(a.funnel.reachedInterview).toBe(2); // j3,j4
+    expect(a.funnel.reachedOffer).toBe(1); // j4
+  });
+
+  it("uses max history rank when current stage is terminal (REJECTED/GHOSTED)", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "REJECTED" }, // history has APPLIED + INTERVIEW
+      { id: "j2", stage: "GHOSTED" }, // history has APPLIED only
+      { id: "j3", stage: "REJECTED" }, // no history → only INTERESTED
+    ]);
+    mockStageHistoryFindMany.mockResolvedValue([
+      { jobId: "j1", toStage: "APPLIED", changedAt: new Date("2026-01-01") },
+      { jobId: "j1", toStage: "INTERVIEW", changedAt: new Date("2026-01-10") },
+      { jobId: "j1", toStage: "REJECTED", changedAt: new Date("2026-01-20") },
+      { jobId: "j2", toStage: "APPLIED", changedAt: new Date("2026-01-05") },
+      { jobId: "j2", toStage: "GHOSTED", changedAt: new Date("2026-02-05") },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.funnel.reachedApplied).toBe(2); // j1, j2
+    expect(a.funnel.reachedInterview).toBe(1); // j1
+    expect(a.funnel.reachedOffer).toBe(0);
+  });
+
+  it("computes conversion rates as integer percentages", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "a", stage: "INTERESTED" },
+      { id: "b", stage: "APPLIED" },
+      { id: "c", stage: "INTERVIEW" },
+      { id: "d", stage: "OFFER" },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    // reachedInterested=4, reachedApplied=3, reachedInterview=2, reachedOffer=1
+    expect(a.funnel.appliedRate).toBe(75); // 3/4
+    expect(a.funnel.interviewRate).toBe(67); // 2/3 rounded
+    expect(a.funnel.offerRate).toBe(50); // 1/2
+  });
+});
+
+describe("getAnalyticsBreakdown — time in stage", () => {
+  it("returns empty record when there are no transitions", async () => {
+    mockJobFindMany.mockResolvedValue([{ id: "j1", stage: "INTERESTED" }]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.timeInStage).toEqual({});
+  });
+
+  it("computes average days for each closed transition, grouped by from-stage", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "INTERVIEW" },
+      { id: "j2", stage: "OFFER" },
+    ]);
+    mockStageHistoryFindMany.mockResolvedValue([
+      // j1: INTERESTED for 4 days, APPLIED for 15 days, then INTERVIEW (open)
+      { jobId: "j1", toStage: "INTERESTED", changedAt: new Date("2026-01-01") },
+      { jobId: "j1", toStage: "APPLIED", changedAt: new Date("2026-01-05") },
+      { jobId: "j1", toStage: "INTERVIEW", changedAt: new Date("2026-01-20") },
+      // j2: APPLIED for 5 days, INTERVIEW for 10 days, then OFFER (open)
+      { jobId: "j2", toStage: "APPLIED", changedAt: new Date("2026-02-01") },
+      { jobId: "j2", toStage: "INTERVIEW", changedAt: new Date("2026-02-06") },
+      { jobId: "j2", toStage: "OFFER", changedAt: new Date("2026-02-16") },
+    ]);
+
+    const a = await getAnalyticsBreakdown(USER_ID);
+
+    expect(a.timeInStage.INTERESTED).toBe(4); // only j1: 4 days
+    expect(a.timeInStage.APPLIED).toBe(10); // (15+5)/2 = 10 days
+    expect(a.timeInStage.INTERVIEW).toBe(10); // only j2 closed: 10 days
+    expect(a.timeInStage.OFFER).toBeUndefined(); // no closed transitions
+  });
+
+  it("scopes the history query by the user's job ids", async () => {
+    mockJobFindMany.mockResolvedValue([
+      { id: "j1", stage: "INTERESTED" },
+      { id: "j2", stage: "APPLIED" },
+    ]);
+
+    await getAnalyticsBreakdown(USER_ID);
+
+    expect(mockStageHistoryFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobId: { in: ["j1", "j2"] } },
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- New \`getAnalyticsBreakdown(userId)\` in \`services/metrics.ts\` returns velocity (rolling 30-day), funnel (max stage reached per job, current + history), and time-in-stage (average days per stage from closed transitions)
- \`/api/metrics\` returns existing dashboard metrics + an \`analytics\` object in one round-trip
- New \`AnalyticsSection\` in \`MetricsPanel\` renders three tiles: velocity (count + change % + 4-week sparkline), stage conversion funnel, and avg time-in-stage list

## Demo backing (A5 — 2 min)
This closes the demo gap for "velocity and stage conversion analytics with actionable insights." Each tile leads with an interpretable number plus a one-line insight (▲/▼ change vs prior 30 days; conversion %s alongside reached counts; per-stage day averages).

## Test plan
- [x] \`bun run test\` — 224/224 pass (was 211 baseline; +13 new service tests, +1 API assertion)
- [x] \`bun run type-check\` — clean
- [x] \`bun lint\` — clean
- [x] \`bun run build\` — clean
- [x] Funnel uses both current stage and history so REJECTED/GHOSTED jobs that reached INTERVIEW are still counted toward the funnel
- [x] Empty/edge cases tested: no jobs, no transitions, prior-30-day = 0 (no div-by-zero), open-ended current stages skipped from time-in-stage

Closes #164