### PR TITLE
fix(ci): use latest vercel CLI directly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          vercel-args: "--prod"
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy to production
+        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `amondnet/vercel-action@v25` (bundles outdated CLI v25.1.0) with direct `vercel@latest` CLI
- Vercel API now requires CLI v47.2.2+, the action can't keep up
- Deploys source to Vercel, builds on their servers where env vars are configured
- Logger fix already deployed (skips file transports on serverless)
- `.env.example` documents all required environment variables

Closes #167
Closes #165

## Testing
- Logger fix verified building locally
- Deploy workflow will be verified on merge