### PR TITLE
fix(deployment): add prisma migrate deploy to CI/CD

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run Prisma Migrate
+        run: bunx prisma migrate deploy
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 


### PR DESCRIPTION
## Summary
- Added a `prisma migrate deploy` step to the `deploy.yml` workflow.
- This ensures database migrations are automatically applied during deployment to production.
- **Prerequisite**: Ensure the `DATABASE_URL` secret is configured in the GitHub repository settings.

Closes #166