### PR TITLE
docs: sync sprint 3 features — research, prep notes, ai/research route

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ These choices are final. Do not suggest alternatives or migrations.
 - `src/styles/` — CSS stylesheets (jakes-resume.css for resume rendering)
 - `src/proxy.ts` — middleware logic for route protection and session refresh
 - `src/scripts/` — database seed and clean scripts
-- `src/app/api/` — API route handlers (auth, health, jobs, documents, profile, settings, metrics, ai/cover-letter, ai/resume, ai/rewrite)
+- `src/app/api/` — API route handlers (auth, health, jobs, documents, profile, settings, metrics, ai/cover-letter, ai/resume, ai/rewrite, ai/research)
 - `src/tests/` — test files organized by module (api, components, hooks, lib, services, utils, \_\_mocks\_\_)
 
 ### Route structure
@@ -52,7 +52,7 @@ These choices are final. Do not suggest alternatives or migrations.
 The app uses Next.js route groups:
 
 - `src/app/(auth)/` — public pages: `login/`, `register/`, `forgot-password/`, `reset-password/`
-- `src/app/(app)/` — protected pages: `dashboard/`, `dashboard/[jobId]/` (job detail with overview, timeline, followups, interviews, documents sections), `documents/`, `documents/[id]/` (document detail), `profile/`, `settings/`, with shared `layout.tsx` that checks auth and renders sidebar
+- `src/app/(app)/` — protected pages: `dashboard/`, `dashboard/[jobId]/` (job detail with overview, timeline, followups, interviews, documents, research, prep-notes sections), `documents/`, `documents/[id]/` (document detail), `profile/`, `settings/`, with shared `layout.tsx` that checks auth and renders sidebar
 
 ### Code style
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,13 @@
 - Resume bullet rewriting.
 - Job-specific resume and cover letter generation.
 - Suggest improvements for user-written content.
+- AI-generated company research (overview, culture, news, role fit, suggested interview questions) — auto-saved per job.
 - AI outputs are editable and versioned.
+
+### 5. Interview Prep Notes
+
+- Structured freeform notes per job: STAR stories, questions to ask interviewers, and talking points.
+- Saved alongside job data, separate from AI-generated research.
 
 ---
 

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -69,6 +69,17 @@ The pipeline uses Bun on Ubuntu with a 10-minute timeout. Concurrent runs on the
 
 Profile, Experience, Education, Skill, Job, JobStageHistory, JobActivity, Document, DocumentVersion, JobDocumentLink, UserSettings
 
+### Notable Job Fields
+
+In addition to core fields (title, company, stage, etc.), the `Job` model carries four AI/prep fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `companyResearch` | `String?` | AI-generated company research (persisted on generation; manually editable) |
+| `prepNotesStar` | `String?` | Interview prep — STAR stories |
+| `prepNotesQuestions` | `String?` | Interview prep — questions to ask interviewers |
+| `prepNotesTalkingPoints` | `String?` | Interview prep — talking points to weave in |
+
 ### Enums
 
 - **JobStage:** `INTERESTED`, `APPLIED`, `INTERVIEW`, `OFFER`, `REJECTED`, `ARCHIVED`
@@ -90,3 +101,16 @@ Profile, Experience, Education, Skill, Job, JobStageHistory, JobActivity, Docume
 - User 1:1 UserSettings (via `userId`)
 
 For the full schema, see `prisma/schema.prisma`.
+
+---
+
+## AI Service (`src/services/ai.ts`)
+
+All AI calls go through Google Gemini (`gemini-2.5-flash`). Four exported functions:
+
+| Function | Endpoint | Description |
+|----------|----------|-------------|
+| `generateResumeDraft(profile, job)` | `POST /api/ai/resume` | Generates a tailored resume draft from the user's profile and a job entry |
+| `generateCoverLetterDraft(profile, job)` | `POST /api/ai/cover-letter` | Generates a job-specific cover letter |
+| `rewriteContent(input)` | `POST /api/ai/rewrite` | Rewrites a content block per a user instruction |
+| `generateCompanyResearch(input)` | `POST /api/ai/research` | Produces structured company research (6 sections: overview, products, culture, news, role fit, suggested questions). Auto-persists to `job.companyResearch`. |


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: added `ai/research` to the API routes list; updated `dashboard/[jobId]/` section listing to include `research` and `prep-notes` sections
- **docs/developer-reference.md**: documented the four new `Job` fields (`companyResearch`, `prepNotesStar`, `prepNotesQuestions`, `prepNotesTalkingPoints`) and added an AI Service table covering all four Gemini-backed functions including the new `generateCompanyResearch`
- **README.md**: expanded the AI Features section to include company research generation; added a new Interview Prep Notes section

No code changes — documentation only.