### PR TITLE
fix(ci): probe production alias in health check, not per-deployment url

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,9 +59,14 @@ jobs:
       # database is reachable. Health endpoint returns 503 on DB failure, so a
       # successful curl here is a real readiness signal — not just "the build
       # uploaded." Retries cover Vercel's brief edge-propagation window.
+      #
+      # We probe the stable production alias, not the per-deployment URL
+      # returned by `vercel deploy`. Vercel Deployment Protection applies to
+      # the unique per-build URLs but not to the production alias domain, so
+      # curl against the per-deployment URL would always return 401.
       - name: Health check
         run: |
-          HEALTH_URL="${{ steps.deploy.outputs.url }}/api/health"
+          HEALTH_URL="https://dartly-ten.vercel.app/api/health"
           echo "Probing $HEALTH_URL"
           curl --fail --show-error --silent \
             --retry 5 --retry-delay 5 --retry-all-errors \


### PR DESCRIPTION
## Root Cause

`vercel deploy --prod` returns a unique per-deployment URL (e.g. `dartly-1flusjvzq-jac352-6637s-projects.vercel.app`). Vercel's **Deployment Protection** is enabled at the project level, which means unauthenticated requests to these unique URLs receive a `401` before they ever reach Next.js. The health check step was probing that URL, so it always got `401` → curl exit code 22 → workflow failure.

The actual deploy succeeded every time. Only the readiness probe was broken.

## Fix

Probe the stable production alias (`https://dartly-ten.vercel.app/api/health`) instead. The production alias domain is exempt from Deployment Protection, so the health endpoint is reachable without credentials as intended.

## What was not changed

- The `vercel deploy` step is unchanged — it still captures the deployment URL for the log output
- The health route itself is correctly unauthenticated (documented in the route file)
- No new secrets required