### PR TITLE
fix(dashboard): default to active jobs instead of persisted archived view

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -24,9 +24,6 @@ export default function DashboardPage() {
   const [showArchived, setShowArchived] = useState(false);
   const [defaultStage, setDefaultStage] = useState<JobStage>("Interested");
   const prefsLoaded = useRef(false);
-  // Tracks whether the user has manually toggled showArchived since mount.
-  // If they have, we don't overwrite their choice when preferences load.
-  const userToggledArchived = useRef(false);
   const [editingJob, setEditingJob] = useState<Job | null>(null);
   const [pendingDeleteJob, setPendingDeleteJob] = useState<Job | null>(null);
   const [pendingArchiveJob, setPendingArchiveJob] = useState<Job | null>(null);
@@ -37,9 +34,6 @@ export default function DashboardPage() {
   const [viewMode, setViewMode] = useViewMode();
   const [metricsKey, setMetricsKey] = useState(0);
 
-  // Load user preferences once on mount and apply showArchived + defaultJobStage.
-  // If the user has already toggled showArchived before this resolves, respect
-  // their choice and only apply defaultStage.
   useEffect(() => {
     const ctrl = new AbortController();
     fetch("/api/settings", { signal: ctrl.signal })
@@ -48,20 +42,14 @@ export default function DashboardPage() {
         if (ctrl.signal.aborted || prefsLoaded.current) return;
         prefsLoaded.current = true;
         const p = prefs ?? DEFAULT_PREFERENCES;
-        if (!userToggledArchived.current) {
-          setShowArchived(p.showArchived);
-        }
         const uiStage = STAGE_PRISMA_TO_UI[p.defaultJobStage] ?? "Interested";
         setDefaultStage(uiStage as JobStage);
       })
-      .catch(() => {
-        // Silently fall back to defaults — preferences are non-critical.
-      });
+      .catch(() => {});
     return () => ctrl.abort();
   }, []);
 
   const handleShowArchivedChange = useCallback((show: boolean) => {
-    userToggledArchived.current = true;
     setShowArchived(show);
   }, []);
 

--- a/src/components/settings/app-preferences-section.tsx
+++ b/src/components/settings/app-preferences-section.tsx
@@ -87,13 +87,6 @@ export function AppPreferencesSection({ preferences, onUpdate }: AppPreferencesS
         </div>
 
         <Toggle
-          checked={preferences.showArchived}
-          onChange={() => onUpdate("showArchived", !preferences.showArchived)}
-          label="Show archived jobs"
-          description="Display archived jobs on the dashboard."
-        />
-
-        <Toggle
           checked={preferences.autoArchiveRejected}
           onChange={() => onUpdate("autoArchiveRejected", !preferences.autoArchiveRejected)}
           label="Auto-archive rejected jobs"

--- a/src/tests/api/settings.test.ts
+++ b/src/tests/api/settings.test.ts
@@ -30,7 +30,6 @@ import { GET, PATCH } from "@/app/api/settings/route";
 const mockUser = { id: "user-123" };
 const defaultPrefs = {
   defaultJobStage: "INTERESTED",
-  showArchived: false,
   dashboardView: "card" as const,
   autoArchiveRejected: false,
   autoArchiveRejectedDays: 30,
@@ -72,24 +71,24 @@ describe("PATCH /api/settings", () => {
     const req = new Request("http://localhost/api/settings", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ showArchived: true }),
+      body: JSON.stringify({ dashboardView: "list" }),
     }) as NextRequest;
     const res = await PATCH(req);
     expect(res.status).toBe(401);
   });
 
   it("updates and returns merged preferences", async () => {
-    const updated = { ...defaultPrefs, showArchived: true };
+    const updated = { ...defaultPrefs, dashboardView: "list" as const };
     mockUpsertSettings.mockResolvedValue(updated);
     const req = new Request("http://localhost/api/settings", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ showArchived: true }),
+      body: JSON.stringify({ dashboardView: "list" }),
     }) as NextRequest;
     const res = await PATCH(req);
     expect(res.status).toBe(200);
     const data = await res.json();
-    expect(data.showArchived).toBe(true);
+    expect(data.dashboardView).toBe("list");
   });
 
   it("returns 400 for invalid input", async () => {

--- a/src/tests/services/settings.test.ts
+++ b/src/tests/services/settings.test.ts
@@ -39,10 +39,10 @@ describe("settings service", () => {
 
     it("merges stored preferences with defaults", async () => {
       mockFindUnique.mockResolvedValue({
-        preferences: { showArchived: true },
+        preferences: { dashboardView: "list" },
       });
       const result = await getSettings("user-1");
-      expect(result.showArchived).toBe(true);
+      expect(result.dashboardView).toBe("list");
       expect(result.defaultJobStage).toBe(DEFAULT_PREFERENCES.defaultJobStage);
     });
   });
@@ -51,20 +51,20 @@ describe("settings service", () => {
     it("creates settings row with partial update merged into defaults", async () => {
       mockFindUnique.mockResolvedValue(null);
       mockUpsert.mockResolvedValue({
-        preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+        preferences: { ...DEFAULT_PREFERENCES, dashboardView: "list" },
       });
 
-      await upsertSettings("user-1", { showArchived: true });
+      await upsertSettings("user-1", { dashboardView: "list" });
 
       expect(mockUpsert).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { userId: "user-1" },
           create: expect.objectContaining({
             userId: "user-1",
-            preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+            preferences: { ...DEFAULT_PREFERENCES, dashboardView: "list" },
           }),
           update: expect.objectContaining({
-            preferences: { ...DEFAULT_PREFERENCES, showArchived: true },
+            preferences: { ...DEFAULT_PREFERENCES, dashboardView: "list" },
           }),
         })
       );
@@ -78,18 +78,18 @@ describe("settings service", () => {
         preferences: {
           ...DEFAULT_PREFERENCES,
           defaultJobStage: "APPLIED",
-          showArchived: true,
+          dashboardView: "list",
         },
       });
 
-      await upsertSettings("user-1", { showArchived: true });
+      await upsertSettings("user-1", { dashboardView: "list" });
 
       expect(mockUpsert).toHaveBeenCalledWith(
         expect.objectContaining({
           update: expect.objectContaining({
             preferences: expect.objectContaining({
               defaultJobStage: "APPLIED",
-              showArchived: true,
+              dashboardView: "list",
             }),
           }),
         })

--- a/src/types/schemas/settings.ts
+++ b/src/types/schemas/settings.ts
@@ -4,7 +4,6 @@ export const DEFAULT_JOB_STAGES = ["INTERESTED", "APPLIED", "INTERVIEW", "OFFER"
 
 export const UserPreferencesSchema = z.object({
   defaultJobStage: z.enum(DEFAULT_JOB_STAGES).optional(),
-  showArchived: z.boolean().optional(),
   dashboardView: z.enum(["card", "list"]).optional(),
   autoArchiveRejected: z.boolean().optional(),
   autoArchiveRejectedDays: z.number().int().min(1).max(365).optional(),

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -2,7 +2,6 @@ export type DashboardView = "card" | "list";
 
 export type UserPreferences = {
   defaultJobStage: "INTERESTED" | "APPLIED" | "INTERVIEW" | "OFFER";
-  showArchived: boolean;
   dashboardView: DashboardView;
   autoArchiveRejected: boolean;
   autoArchiveRejectedDays: number;
@@ -10,7 +9,6 @@ export type UserPreferences = {
 
 export const DEFAULT_PREFERENCES: UserPreferences = {
   defaultJobStage: "INTERESTED",
-  showArchived: false,
   dashboardView: "card",
   autoArchiveRejected: false,
   autoArchiveRejectedDays: 30,


### PR DESCRIPTION
## Summary

- Remove `showArchived` from persisted user preferences so the dashboard always defaults to showing active (non-archived) jobs on load
- The archived toggle in the filter bar remains functional as a session-only control
- Remove the "Show archived jobs" toggle from the Settings page (no longer a persisted preference)
- Update tests to cover `dashboardView` instead of `showArchived`

## Root Cause

The `showArchived` preference was saved to the database and restored on every dashboard visit. Once toggled on (even accidentally), the dashboard would permanently default to archived-only view.