### PR TITLE
feat(documents): add manual status selector to document detail page

### DIFF
--- a/src/app/(app)/documents/[id]/page.tsx
+++ b/src/app/(app)/documents/[id]/page.tsx
@@ -56,6 +56,12 @@ const STATUS_STYLES: Record<string, string> = {
   UPLOADED: "bg-blue-500/10 text-blue-400",
 };
 
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: "DRAFT", label: "Draft" },
+  { value: "READY", label: "Ready" },
+  { value: "UPLOADED", label: "Uploaded" },
+];
+
 type ViewMode = "preview" | "markdown" | "edit";
 
 const VIEW_OPTIONS: { value: ViewMode; label: string }[] = [
@@ -83,6 +89,7 @@ export default function DocumentDetailPage({ params }: { params: Promise<{ id: s
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState("");
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const [updatingStatus, setUpdatingStatus] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -343,6 +350,33 @@ export default function DocumentDetailPage({ params }: { params: Promise<{ id: s
     if (e.key === "Escape") setRenaming(false);
   }
 
+  async function handleStatusChange(newStatus: string) {
+    if (!doc || newStatus === doc.status) return;
+    setUpdatingStatus(true);
+    try {
+      const res = await fetch(`/api/documents/${doc.id}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (res.status === 401) {
+        router.push("/login");
+        return;
+      }
+      if (res.ok) {
+        const updated = await res.json();
+        setDoc(updated);
+        showToast("Status updated");
+      } else {
+        showToast("Failed to update status", "error");
+      }
+    } catch {
+      showToast("Failed to update status", "error");
+    } finally {
+      setUpdatingStatus(false);
+    }
+  }
+
   // Persist the full tag list on every change. Optimistically update local
   // state so the chip input stays responsive; revert on server rejection.
   async function handleTagsChange(nextTags: string[]) {
@@ -469,11 +503,21 @@ export default function DocumentDetailPage({ params }: { params: Promise<{ id: s
               >
                 {TYPE_LABELS[doc.type] ?? "Other"}
               </span>
-              <span
-                className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium shrink-0 ${STATUS_STYLES[doc.status] ?? STATUS_STYLES.DRAFT}`}
-              >
-                {doc.status}
-              </span>
+              {isArchived ? (
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium shrink-0 ${STATUS_STYLES.ARCHIVED}`}
+                >
+                  ARCHIVED
+                </span>
+              ) : (
+                <Select
+                  value={doc.status}
+                  onChange={handleStatusChange}
+                  options={STATUS_OPTIONS}
+                  disabled={updatingStatus}
+                  className="w-28"
+                />
+              )}
             </div>
             <p className="text-xs text-zinc-500">
               v{doc.versionNumber} &middot; Created{" "}

--- a/src/app/api/documents/[id]/status/route.ts
+++ b/src/app/api/documents/[id]/status/route.ts
@@ -1,0 +1,34 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { handleApiError } from "@/lib/api-error";
+import { withHttpLogging } from "@/lib/api-wrapper";
+import logger from "@/lib/logger";
+import { requireAuth } from "@/lib/requireAuth";
+import { validateBody } from "@/lib/validate-body";
+import { updateDocumentStatus } from "@/services/documents";
+import { UpdateDocumentStatusSchema } from "@/types/schemas";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  return withHttpLogging(request, async () => {
+    try {
+      const user = await requireAuth();
+      const { id } = await context.params;
+      const { status } = await validateBody(request, UpdateDocumentStatusSchema);
+
+      const doc = await updateDocumentStatus(id, user.id, status);
+      if (!doc) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      logger.info("Document status updated", {
+        userId: user.id,
+        documentId: id,
+        status,
+      });
+      return NextResponse.json(doc, { status: 200 });
+    } catch (err) {
+      return handleApiError(err);
+    }
+  });
+}

--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -1,6 +1,6 @@
 import { Prisma, type Document, type DocumentType, type DocumentVersion } from "@prisma/client";
 import { prisma } from "@/services/prisma";
-import type { DocumentResponse, DocumentVersionResponse } from "@/types/document";
+import type { DocumentResponse, DocumentStatus, DocumentVersionResponse } from "@/types/document";
 import { normalizeTags } from "@/utils/tags";
 
 // Two concurrent saves on the same document can both compute the same
@@ -377,6 +377,25 @@ export async function getDocumentsForJob(jobId: string, userId: string) {
         latestVersionNumber: latest.versionNumber,
       };
     });
+}
+
+export async function updateDocumentStatus(
+  id: string,
+  userId: string,
+  status: DocumentStatus
+) {
+  const { count } = await prisma.document.updateMany({
+    where: { id, userId, isDeleted: false },
+    data: { status, updatedAt: new Date() },
+  });
+  if (count === 0) return null;
+
+  const doc = await prisma.document.findFirst({
+    where: { id, userId, isDeleted: false },
+    include: { versions: { orderBy: { versionNumber: "desc" }, take: 1 } },
+  });
+  if (!doc || doc.versions.length === 0) return null;
+  return withDocumentVersionId(doc, doc.versions[0]);
 }
 
 export async function archiveDocument(id: string, userId: string) {

--- a/src/tests/api/documents-status.test.ts
+++ b/src/tests/api/documents-status.test.ts
@@ -1,0 +1,101 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUpdateDocumentStatus, mockRequireAuth, mockValidateBody } = vi.hoisted(() => ({
+  mockUpdateDocumentStatus: vi.fn(),
+  mockRequireAuth: vi.fn(),
+  mockValidateBody: vi.fn(),
+}));
+
+vi.mock("@/lib/api-wrapper", () => ({
+  withHttpLogging: vi.fn((_req: unknown, handler: () => unknown) => handler()),
+}));
+
+vi.mock("@/lib/requireAuth", () => ({
+  requireAuth: mockRequireAuth,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  default: { info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/validate-body", () => ({
+  validateBody: mockValidateBody,
+}));
+
+vi.mock("@/services/documents", () => ({
+  updateDocumentStatus: mockUpdateDocumentStatus,
+}));
+
+import { PATCH } from "@/app/api/documents/[id]/status/route";
+
+const mockUser = { id: "user-123" };
+const mockDocResponse = {
+  id: "doc-1",
+  type: "RESUME",
+  name: "My Resume",
+  status: "READY",
+  content: "Resume content",
+  versionNumber: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function makeRequest(body: object): NextRequest {
+  return new Request("http://localhost/api/documents/doc-1/status", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+const context = { params: Promise.resolve({ id: "doc-1" }) };
+
+describe("PATCH /api/documents/[id]/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue(mockUser);
+  });
+
+  it("returns 200 with updated document", async () => {
+    const updated = { ...mockDocResponse, status: "READY" };
+    mockUpdateDocumentStatus.mockResolvedValue(updated);
+    mockValidateBody.mockResolvedValue({ status: "READY" });
+
+    const res = await PATCH(makeRequest({ status: "READY" }), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("READY");
+    expect(mockUpdateDocumentStatus).toHaveBeenCalledWith("doc-1", mockUser.id, "READY");
+  });
+
+  it("returns 404 when document not found", async () => {
+    mockUpdateDocumentStatus.mockResolvedValue(null);
+    mockValidateBody.mockResolvedValue({ status: "DRAFT" });
+
+    const res = await PATCH(makeRequest({ status: "DRAFT" }), context);
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Document not found");
+  });
+
+  it("returns 400 for invalid status value", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockValidateBody.mockRejectedValue(new ApiError(400, "Invalid status"));
+
+    const res = await PATCH(makeRequest({ status: "INVALID" }), context);
+    expect(res.status).toBe(400);
+    expect(mockUpdateDocumentStatus).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    const { ApiError } = await import("@/lib/api-error");
+    mockRequireAuth.mockRejectedValue(new ApiError(401, "Unauthorized"));
+
+    const res = await PATCH(makeRequest({ status: "READY" }), context);
+    expect(res.status).toBe(401);
+    expect(mockUpdateDocumentStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/types/schemas/document.ts
+++ b/src/types/schemas/document.ts
@@ -52,3 +52,7 @@ export const RenameDocumentSchema = z.object({
 export const UpdateDocumentTagsSchema = z.object({
   tags: TagsSchema,
 });
+
+export const UpdateDocumentStatusSchema = z.object({
+  status: z.enum(["DRAFT", "READY", "UPLOADED"]),
+});

--- a/src/types/schemas/index.ts
+++ b/src/types/schemas/index.ts
@@ -8,6 +8,7 @@ export {
   RewriteContentSchema,
   TagsSchema,
   UpdateDocumentContentSchema,
+  UpdateDocumentStatusSchema,
   UpdateDocumentTagsSchema,
 } from "./document";
 export { CreateJobSchema, JobStageSchema, UpdateJobSchema } from "./job";


### PR DESCRIPTION
## Summary

- Add a manual status selector (DRAFT / READY / UPLOADED) to the document detail page, replacing the static status badge
- New `PATCH /api/documents/[id]/status` endpoint with Zod validation (ARCHIVED is not selectable — it remains an action via the archive button)
- New `updateDocumentStatus` service function with `userId` scoping and `isDeleted` guard
- Status badge remains as a static pill when the document is archived
- Tests for the new endpoint (4 test cases: success, 404, 400 validation, 401 auth)